### PR TITLE
Feature/wp and user linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@ckeditor/ckeditor5-ui": "^10.1.0",
     "@ckeditor/ckeditor5-engine": "^10.1.0",
     "@ckeditor/ckeditor5-widget": "^10.1.0",
+    "@ckeditor/ckeditor5-enter": "^10.1.0",
     "babel-minify-webpack-plugin": "^0.3.0",
     "postcss-loader": "^2.0.10",
     "raw-loader": "^0.5.1",

--- a/src/op-ckeditor.js
+++ b/src/op-ckeditor.js
@@ -27,6 +27,7 @@ import OPMacroWpButtonPlugin from './plugins/op-macro-wp-button/op-macro-wp-butt
 import OPWikiIncludePagePlugin from './plugins/op-macro-wiki-include/op-macro-wiki-include-plugin';
 import OPLinkingWpPlugin from './plugins/op-linking-wp-plugin';
 import {AtJsPlugin} from './plugins/op-atjs-plugin/atjs-plugin';
+import OPMentioningPlugin from './plugins/op-mentioning-plugin';
 
 
 export class BalloonEditor extends BalloonEditorBase {}
@@ -63,6 +64,7 @@ const config = {
 
 		AtJsPlugin,
 		OPLinkingWpPlugin,
+		OPMentioningPlugin,
 
 		CommonMark,
 		Table,

--- a/src/op-ckeditor.js
+++ b/src/op-ckeditor.js
@@ -25,6 +25,8 @@ import OPMacroTocPlugin from './plugins/op-macro-toc-plugin';
 import OPMacroEmbeddedTable from './plugins/op-macro-embedded-table/embedded-table-plugin';
 import OPMacroWpButtonPlugin from './plugins/op-macro-wp-button/op-macro-wp-button-plugin';
 import OPWikiIncludePagePlugin from './plugins/op-macro-wiki-include/op-macro-wiki-include-plugin';
+import OPLinkingWpPlugin from './plugins/op-linking-wp-plugin';
+import {AtJsPlugin} from './plugins/op-atjs-plugin/atjs-plugin';
 
 
 export class BalloonEditor extends BalloonEditorBase {}
@@ -58,6 +60,9 @@ const config = {
 		OPMacroEmbeddedTable,
 		OPMacroWpButtonPlugin,
 		OPWikiIncludePagePlugin,
+
+		AtJsPlugin,
+		OPLinkingWpPlugin,
 
 		CommonMark,
 		Table,

--- a/src/plugins/op-atjs-plugin/atjs-enter-command.js
+++ b/src/plugins/op-atjs-plugin/atjs-enter-command.js
@@ -1,0 +1,18 @@
+import EnterCommand from "@ckeditor/ckeditor5-enter/src/entercommand"
+
+export default class AtJsEnterCommand extends EnterCommand {
+
+	execute() {
+		if (!this.atJsOpen) {
+			super.execute()
+		}
+	}
+
+	get isAtJsOpen() {
+		return this.atJsOpen;
+	}
+
+	set isAtJsOpen(value) {
+		this.atJsOpen = value;
+	}
+}

--- a/src/plugins/op-atjs-plugin/atjs-plugin.js
+++ b/src/plugins/op-atjs-plugin/atjs-plugin.js
@@ -1,0 +1,20 @@
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import AtJsEnterCommand from './atjs-enter-command';
+
+export class AtJsPlugin extends Plugin {
+
+	static get pluginName() {
+		return 'atjs';
+	}
+
+	static get requires() {
+		return [ AtJsEnterCommand ];
+	}
+
+	init() {
+		const editor = this.editor;
+
+		editor.commands.get("enter").destroy();
+		editor.commands.add("enter", new AtJsEnterCommand(editor) );
+	}
+}

--- a/src/plugins/op-atjs-plugin/atjs-setup.js
+++ b/src/plugins/op-atjs-plugin/atjs-setup.js
@@ -1,133 +1,141 @@
-export function setupAtJs(editor, url) {
-	editor.model.document.once('change', () => {
-		let editable = jQuery(editor.element).closest('op-ckeditor-form').find('.ck-editor__editable');
+export function setupAtJs(editor, options) {
+	let editable;
 
-		editable.atwho({
-			at: '#',
-			startWithSpace: false,
-			searchKey: 'id_subject',
-			displayTpl: '<li data-value="${atwho-at}${id}">${id}</li>',
-			insertTpl: "${atwho-at}${id}",
-			limit: 10,
-			callbacks: {
-				/*
-                 Readd the 'span.atwho-query' used for positioning the dropdown.
-                 The ckeditor will have removed the span added by at.js.
-                 The functionality mimics at.js' behaviour. It additionally stores the information in the at.js instance
-                 for later retrieval (#beforeInsert) when we again need to reconstruct the span.
-                */
-				remoteFilter: function (query, callback) {
-					let that = this;
+	let reconstructRangeFromCurrentPosition = function (query) {
+		let $query = newAtJsSpan(this.app.document);
+		let range = this._getRange();
+		let index = range.startOffset - this.at.length - query.length;
 
-					jQuery.getJSON(url, {q: query, scope: 'all'}, function (data) {
-						if (data) {
-							addConcatenatedIdSubject(data);
+		range.setStart(range.startContainer, index);
 
-							that.query.el = reconstructRangeFromCurrentPosition.call(that, query);
+		this.currentRangeProperties = {current: range, start: index, end: range.endOffset};
 
-							if (jQuery(editable).is(':visible')) {
-								callback(data);
-							}
-							else {
-								// discard the results if the textarea is no longer visible,
-								// i.e. nobody cares for the results
-								callback([]);
-							}
+		range.surroundContents($query.get(0));
+
+		return $query;
+	};
+
+	let reconstructRangeFromCurrentProperties = function () {
+		let $query = newAtJsSpan(this.app.document);
+		let currentRange = this.currentRangeProperties.current;
+		let range = currentRange.cloneRange();
+		let startTextNode = currentRange.startContainer.childNodes[0];
+		let endTextNode = currentRange.endContainer.childNodes[0];
+
+		range.setStart(startTextNode, this.currentRangeProperties.start);
+		range.setEnd(endTextNode, this.currentRangeProperties.end);
+		range.surroundContents($query.get(0));
+
+		return $query;
+	};
+
+	let newAtJsSpan = function (doc) {
+		return jQuery('<span/>', doc).addClass('atwho-query');
+	};
+
+	let config = jQuery.extend({}, {
+		at: '#',
+		startWithSpace: false,
+		searchKey: 'id_subject',
+		displayTpl: '<li data-value="${atwho-at}${id}">${to_s}</li>',
+		insertTpl: "${atwho-at}${id}",
+		limit: 10,
+		callbacks: {
+			/*
+             Readd the 'span.atwho-query' used for positioning the dropdown.
+             The ckeditor will have removed the span added by at.js.
+             The functionality mimics at.js' behaviour. It additionally stores the information in the at.js instance
+             for later retrieval (#beforeInsert) when we again need to reconstruct the span.
+            */
+			remoteFilter: function (query, callback) {
+				let that = this;
+
+				this.getOpt('remoteUrl')(query, function (data) {
+					if (data) {
+						data = that.getOpt('remoteDataPreparation').call(that, data);
+
+						that.query.el = reconstructRangeFromCurrentPosition.call(that, query);
+
+						if (jQuery(editable).is(':visible')) {
+							callback(data);
 						}
-					});
-				},
-				/*
-                  Override default sorting to not sort as that is already done in the backend
-                */
-				sorter: function (query, items, search_key) {
-					return items;
-				},
-				/*
-                  Readd the 'span.atwho-query' used for positioning the dropdown.
-                  The ckeditor will have removed the span added by us in the remoteFilter callback again.
-                  We rely on the information used in the remoteFilter callback to reconstruct the correct range we than surround with the span
-                  but cannot use the exact same range as ranges keep track of changes to the dom. As the span gets removed by ckeditor, the span
-                  is no longer part of the dom and the range points to an unattached fragement.
-                  For unknown reasons, the range's start- and end-container also buble up one level which is why we need to take their first
-                  child element, a text node, again.
-                */
-				beforeInsert: function (value, $li, e) {
-					this.query.el = reconstructRangeFromCurrentProperties.call(this);
-
-					return value;
-
-				}
-			},
-			functionOverrides: {
-				/*
-				  Override the insert function. This is basically a copy of at.js' insert function with the focus
-				  functionality removed.
-				  The default insert function set the focus to the beginning of the editor field as it focused the contenteditable editor.
-				  This is undesirable if there is an embedded contenteditable e.g. the tds of a table in which the string is inserted. The focus should
-				  stay in that td.
-				*/
-				insert: function (content, $li) {
-					let data, range, suffix, suffixNode;
-					suffix = (suffix = this.getOpt('suffix')) === "" ? suffix : suffix || "\u00A0";
-					data = $li.data('item-data');
-					this.query.el.removeClass('atwho-query').addClass('atwho-inserted').html(content).attr('data-atwho-at-query', "" + data['atwho-at'] + this.query.text).attr('contenteditable', "false");
-					if (range = this._getRange()) {
-						if (this.query.el.length) {
-							range.setEndAfter(this.query.el[0]);
+						else {
+							// discard the results if the textarea is no longer visible,
+							// i.e. nobody cares for the results
+							callback([]);
 						}
-						range.collapse(false);
-						range.insertNode(suffixNode = this.app.document.createTextNode("" + suffix));
-						this._setRange('after', suffixNode, range);
 					}
-					return this.$inputor.change();
-				}
+				});
+			},
+			/*
+              Override default sorting to not sort as that is already done in the backend
+            */
+			sorter: function (query, items, search_key) {
+				return items;
+			},
+			/*
+              Readd the 'span.atwho-query' used for positioning the dropdown.
+              The ckeditor will have removed the span added by us in the remoteFilter callback again.
+              We rely on the information used in the remoteFilter callback to reconstruct the correct range we than surround with the span
+              but cannot use the exact same range as ranges keep track of changes to the dom. As the span gets removed by ckeditor, the span
+              is no longer part of the dom and the range points to an unattached fragement.
+              For unknown reasons, the range's start- and end-container also buble up one level which is why we need to take their first
+              child element, a text node, again.
+            */
+			beforeInsert: function (value, $li, e) {
+				this.query.el = reconstructRangeFromCurrentProperties.call(this);
+
+				return value;
+
 			}
-		});
+		},
+		functionOverrides: {
+			/*
+              Override the insert function. This is basically a copy of at.js' insert function with the focus
+              functionality removed.
+              The default insert function set the focus to the beginning of the editor field as it focused the contenteditable editor.
+              This is undesirable if there is an embedded contenteditable e.g. the tds of a table in which the string is inserted. The focus should
+              stay in that td.
+            */
+			insert: function (content, $li) {
+				let data, range, suffix, suffixNode;
+				suffix = (suffix = this.getOpt('suffix')) === "" ? suffix : suffix || "\u00A0";
+				data = $li.data('item-data');
+				this.query.el.removeClass('atwho-query').addClass('atwho-inserted').html(content).attr('data-atwho-at-query', "" + data['atwho-at'] + this.query.text).attr('contenteditable', "false");
+				if (range = this._getRange()) {
+					if (this.query.el.length) {
+						range.setEndAfter(this.query.el[0]);
+					}
+					range.collapse(false);
+					range.insertNode(suffixNode = this.app.document.createTextNode("" + suffix));
+					this._setRange('after', suffixNode, range);
+				}
+				return this.$inputor.change();
+			}
+		}
+	}, options);
+
+	editor.model.document.once('change', () => {
+		if (options.isSupportedContext && !options.isSupportedContext()) {
+			return;
+		}
+
+		editable = jQuery(editor.element);
+
+		if (!editable.is('.ck-editor__editable')) {
+			editable = editable.closest('op-ckeditor-form').find('.ck-editor__editable');
+		}
+
+		editable.atwho(config);
 
 		// disable enter when atwho is displayed, reenable it once atwho is done
-		jQuery(editor.ui.view.element).on('shown.atwho', () => {
-			editor.commands.get("enter").isAtJsOpen = true;
-		});
-		jQuery(editor.ui.view.element).on('hidden.atwho', () => {
-			editor.commands.get("enter").isAtJsOpen = false;
-		});
+		jQuery(editable)
+			.on('shown.atwho', () => {
+				editor.commands.get("enter").isAtJsOpen = true;
+			})
+			.on('hidden.atwho', () => {
+				editor.commands.get("enter").isAtJsOpen = false;
+			});
 
-		let addConcatenatedIdSubject = function (data) {
-			for (let i = data.length - 1; i >= 0; i--) {
-				data[i]['id_subject'] = data[i]['id'].toString() + ' ' + data[i]['subject'];
-			}
-		};
-
-		let reconstructRangeFromCurrentPosition = function (query) {
-			let $query = newAtJsSpan(this.app.document);
-			let range = this._getRange();
-			let index = range.startOffset - this.at.length - query.length;
-
-			range.setStart(range.startContainer, index);
-
-			this.currentRangeProperties = {current: range, start: index, end: range.endOffset};
-
-			range.surroundContents($query.get(0));
-
-			return $query;
-		};
-
-		let reconstructRangeFromCurrentProperties = function () {
-			let $query = newAtJsSpan(this.app.document);
-			let currentRange = this.currentRangeProperties.current;
-			let range = currentRange.cloneRange();
-			let startTextNode = currentRange.startContainer.childNodes[0];
-			let endTextNode = currentRange.endContainer.childNodes[0];
-
-			range.setStart(startTextNode, this.currentRangeProperties.start);
-			range.setEnd(endTextNode, this.currentRangeProperties.end);
-			range.surroundContents($query.get(0));
-
-			return $query;
-		};
-
-		let newAtJsSpan = function (doc) {
-			return jQuery('<span/>', doc).addClass('atwho-query');
-		}
 	});
 }

--- a/src/plugins/op-atjs-plugin/atjs-setup.js
+++ b/src/plugins/op-atjs-plugin/atjs-setup.js
@@ -1,0 +1,133 @@
+export function setupAtJs(editor, url) {
+	editor.model.document.once('change', () => {
+		let editable = jQuery(editor.element).closest('op-ckeditor-form').find('.ck-editor__editable');
+
+		editable.atwho({
+			at: '#',
+			startWithSpace: false,
+			searchKey: 'id_subject',
+			displayTpl: '<li data-value="${atwho-at}${id}">${id}</li>',
+			insertTpl: "${atwho-at}${id}",
+			limit: 10,
+			callbacks: {
+				/*
+                 Readd the 'span.atwho-query' used for positioning the dropdown.
+                 The ckeditor will have removed the span added by at.js.
+                 The functionality mimics at.js' behaviour. It additionally stores the information in the at.js instance
+                 for later retrieval (#beforeInsert) when we again need to reconstruct the span.
+                */
+				remoteFilter: function (query, callback) {
+					let that = this;
+
+					jQuery.getJSON(url, {q: query, scope: 'all'}, function (data) {
+						if (data) {
+							addConcatenatedIdSubject(data);
+
+							that.query.el = reconstructRangeFromCurrentPosition.call(that, query);
+
+							if (jQuery(editable).is(':visible')) {
+								callback(data);
+							}
+							else {
+								// discard the results if the textarea is no longer visible,
+								// i.e. nobody cares for the results
+								callback([]);
+							}
+						}
+					});
+				},
+				/*
+                  Override default sorting to not sort as that is already done in the backend
+                */
+				sorter: function (query, items, search_key) {
+					return items;
+				},
+				/*
+                  Readd the 'span.atwho-query' used for positioning the dropdown.
+                  The ckeditor will have removed the span added by us in the remoteFilter callback again.
+                  We rely on the information used in the remoteFilter callback to reconstruct the correct range we than surround with the span
+                  but cannot use the exact same range as ranges keep track of changes to the dom. As the span gets removed by ckeditor, the span
+                  is no longer part of the dom and the range points to an unattached fragement.
+                  For unknown reasons, the range's start- and end-container also buble up one level which is why we need to take their first
+                  child element, a text node, again.
+                */
+				beforeInsert: function (value, $li, e) {
+					this.query.el = reconstructRangeFromCurrentProperties.call(this);
+
+					return value;
+
+				}
+			},
+			functionOverrides: {
+				/*
+				  Override the insert function. This is basically a copy of at.js' insert function with the focus
+				  functionality removed.
+				  The default insert function set the focus to the beginning of the editor field as it focused the contenteditable editor.
+				  This is undesirable if there is an embedded contenteditable e.g. the tds of a table in which the string is inserted. The focus should
+				  stay in that td.
+				*/
+				insert: function (content, $li) {
+					let data, range, suffix, suffixNode;
+					suffix = (suffix = this.getOpt('suffix')) === "" ? suffix : suffix || "\u00A0";
+					data = $li.data('item-data');
+					this.query.el.removeClass('atwho-query').addClass('atwho-inserted').html(content).attr('data-atwho-at-query', "" + data['atwho-at'] + this.query.text).attr('contenteditable', "false");
+					if (range = this._getRange()) {
+						if (this.query.el.length) {
+							range.setEndAfter(this.query.el[0]);
+						}
+						range.collapse(false);
+						range.insertNode(suffixNode = this.app.document.createTextNode("" + suffix));
+						this._setRange('after', suffixNode, range);
+					}
+					return this.$inputor.change();
+				}
+			}
+		});
+
+		// disable enter when atwho is displayed, reenable it once atwho is done
+		jQuery(editor.ui.view.element).on('shown.atwho', () => {
+			editor.commands.get("enter").isAtJsOpen = true;
+		});
+		jQuery(editor.ui.view.element).on('hidden.atwho', () => {
+			editor.commands.get("enter").isAtJsOpen = false;
+		});
+
+		let addConcatenatedIdSubject = function (data) {
+			for (let i = data.length - 1; i >= 0; i--) {
+				data[i]['id_subject'] = data[i]['id'].toString() + ' ' + data[i]['subject'];
+			}
+		};
+
+		let reconstructRangeFromCurrentPosition = function (query) {
+			let $query = newAtJsSpan(this.app.document);
+			let range = this._getRange();
+			let index = range.startOffset - this.at.length - query.length;
+
+			range.setStart(range.startContainer, index);
+
+			this.currentRangeProperties = {current: range, start: index, end: range.endOffset};
+
+			range.surroundContents($query.get(0));
+
+			return $query;
+		};
+
+		let reconstructRangeFromCurrentProperties = function () {
+			let $query = newAtJsSpan(this.app.document);
+			let currentRange = this.currentRangeProperties.current;
+			let range = currentRange.cloneRange();
+			let startTextNode = currentRange.startContainer.childNodes[0];
+			let endTextNode = currentRange.endContainer.childNodes[0];
+
+			range.setStart(startTextNode, this.currentRangeProperties.start);
+			range.setEnd(endTextNode, this.currentRangeProperties.end);
+			range.surroundContents($query.get(0));
+
+			return $query;
+		};
+
+		let newAtJsSpan = function (doc) {
+			return jQuery('<span/>', doc).addClass('atwho-query');
+		}
+	});
+}

--- a/src/plugins/op-linking-wp-plugin.js
+++ b/src/plugins/op-linking-wp-plugin.js
@@ -9,8 +9,23 @@ export default class OPLinkingWpPlugin extends Plugin {
 
 	init() {
 		const editor = this.editor;
-		const url = window.OpenProject.urlRoot + '/work_packages/auto_complete.json';
 
-		setupAtJs(editor, url);
+
+		let options = {
+			remoteUrl: function(query, func) {
+				let url = window.OpenProject.urlRoot + `/work_packages/auto_complete.json`;
+
+				jQuery.getJSON(url, {q: query, scope: 'all'}, func)
+			},
+			remoteDataPreparation: function(data) {
+				for (let i = data.length - 1; i >= 0; i--) {
+					data[i]['id_subject'] = data[i]['id'].toString() + ' ' + data[i]['subject'];
+				}
+
+				return data;
+			}
+		};
+
+		setupAtJs(editor, options);
 	}
 }

--- a/src/plugins/op-linking-wp-plugin.js
+++ b/src/plugins/op-linking-wp-plugin.js
@@ -1,0 +1,16 @@
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import {setupAtJs} from './op-atjs-plugin/atjs-setup';
+
+export default class OPLinkingWpPlugin extends Plugin {
+
+	static get pluginName() {
+		return 'OPLinkingWp';
+	}
+
+	init() {
+		const editor = this.editor;
+		const url = window.OpenProject.urlRoot + '/work_packages/auto_complete.json';
+
+		setupAtJs(editor, url);
+	}
+}

--- a/src/plugins/op-mentioning-plugin.js
+++ b/src/plugins/op-mentioning-plugin.js
@@ -1,0 +1,55 @@
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import {setupAtJs} from './op-atjs-plugin/atjs-setup';
+
+export default class OPMentioningPlugin extends Plugin {
+
+	static get pluginName() {
+		return 'OPMentioning';
+	}
+
+	init() {
+		const editor = this.editor;
+		const getOPService = function(name) {
+			return editor.config.openProject.pluginContext.services[name];
+		};
+		const getOPContext = function() {
+			const opConfig = editor.config.openProject;
+
+			return opConfig && opConfig.context;
+		}
+
+		let options = {
+			searchKey: 'id_principal',
+			displayTpl: '<li data-value="#{_type}#${id}">${name}</li>',
+			insertTpl: "${typePrefix}#${id}",
+			startWithSpace: true,
+			suffix: '',
+			acceptSpaceBar: true,
+			highlightFirst: true,
+			at: '@',
+			remoteDataPreparation: function(data) {
+				const principals = data["_embedded"]["elements"];
+				const sanitizer = getOPService('htmlSanitizeService');
+
+				for (let i = principals.length - 1; i >= 0; i--) {
+					principals[i]['id_principal'] = sanitizer.sanitize(principals[i]['id'].toString() + ' ' + principals[i]['name']);
+					principals[i]['typePrefix'] = principals[i]['_type'].toLowerCase();
+				}
+
+				return principals;
+			},
+			isSupportedContext: function() {
+				const context = getOPContext();
+
+				return context && context._type === 'WorkPackage'
+			},
+			remoteUrl: function(query, func) {
+				const url = getOPService('pathHelperService').api.v3.principals(getOPContext().project.id, query);
+
+                jQuery.getJSON(url, func);
+			}
+		};
+
+		setupAtJs(editor, options);
+	}
+}


### PR DESCRIPTION
Enables:

* Mentioning users by name `@Some user`
* referencing work packages `#123`

It uses at.js for the heavylifting but has to adapt and override parts of at.js and ckeditor in order to succeed:
* ckeditor constantly removes the span added by at.js to position the dropdown. The span is therefore reconstructed in two callbacks. I tried adding the span element to the schema but to no avail. It might be possible to write an equal span to the model directly but I did not test this hypothesis.
* The default "enter" behaviour is disabled when at.js is open to avoid adding a newline upon selecting an element form the dropdown. 

There is a limitation in the PR I did not address:
* The dependency on atjs is not moved from OpenProject to this build although OpenProject now does no longer depend on atjs itself.