### PR TITLE
remove image on attachment removal, communicate image upload

### DIFF
--- a/src/op-plugins.js
+++ b/src/op-plugins.js
@@ -30,6 +30,7 @@ import CommonMark from "@ckeditor/ckeditor5-markdown-gfm/src/commonmark";
 import Table from "@ckeditor/ckeditor5-table/src/table";
 import TableToolbar from "@ckeditor/ckeditor5-table/src/tabletoolbar";
 import OPMacroListPlugin from "./plugins/op-macro-list-plugin";
+import OPAttachmentListenerPlugin from './plugins/op-attachment-listener-plugin';
 
 // We divide our plugins into separate concerns here
 // in order to enable / disable each group by configuration
@@ -48,7 +49,8 @@ export const opMentioningPlugins = [
 ];
 
 export const opImageUploadPlugins = [
-	OpUploadPlugin
+	OpUploadPlugin,
+	OPAttachmentListenerPlugin
 ];
 
 export const builtinPlugins = [

--- a/src/plugins/op-attachment-listener-plugin.js
+++ b/src/plugins/op-attachment-listener-plugin.js
@@ -1,0 +1,29 @@
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import Selection from '@ckeditor/ckeditor5-engine/src/model/selection';
+
+export default class OPAttachmentListenerPlugin extends Plugin {
+	static get pluginName() {
+		return 'OPAttachmentListener';
+	}
+
+	init() {
+		let editor = this.editor;
+
+		editor.model.on('op:attachment-removed', (_, urls) => {
+			this.removeDeletedImage(urls)
+		});
+	}
+
+	removeDeletedImage(urls) {
+		let root = this.editor.model.document.getRoot();
+
+		for (const child of Array.from(root.getChildren())) {
+			if (child.name === 'image' && urls.indexOf(child.getAttribute('src')) > -1) {
+				const selection = new Selection( child, 'on' );
+
+				this.editor.model.deleteContent(selection);
+			}
+		}
+
+	}
+}

--- a/src/plugins/op-upload-plugin.js
+++ b/src/plugins/op-upload-plugin.js
@@ -17,7 +17,7 @@ export default class OpUploadPlugin extends Plugin {
     init() {
         this.editor.plugins.get('FileRepository').createUploadAdapter = (loader) => {
 			const resource = getOPResource(this.editor);
-			return new OpUploadResourceAdapter(loader, resource);
+			return new OpUploadResourceAdapter(loader, resource, this.editor);
 		}
     }
 }

--- a/src/plugins/op-upload-resource-adapter.js
+++ b/src/plugins/op-upload-resource-adapter.js
@@ -1,7 +1,8 @@
 export default class OpUploadResourceAdapter {
-    constructor(loader, resource) {
+    constructor(loader, resource, editor) {
         this.loader = loader;
         this.resource = resource;
+        this.editor = editor;
     }
 
     upload() {
@@ -14,7 +15,11 @@ export default class OpUploadResourceAdapter {
 
 		return resource
 			.uploadAttachments([this.loader.file])
-			.then((result) => this.buildResponse(result[0]));
+			.then((result) => {
+				this.editor.model.fire('op:attachment-added', result);
+
+				return this.buildResponse(result[0])
+			});
 	}
 
 	buildResponse(result) {


### PR DESCRIPTION
Adds a two way communication (event based) for when an attachment is added via the image upload button and when an attachment is removed outside the editor. For the later, the editor removes the embedded image.