### PR TITLE
Implement markdown source button

### DIFF
--- a/src/helpers/button-disabler.js
+++ b/src/helpers/button-disabler.js
@@ -1,0 +1,47 @@
+import FileDialogButtonView from '@ckeditor/ckeditor5-upload/src/ui/filedialogbuttonview';
+
+export function getToolbarItems(editor) {
+	editor.__currentlyDisabled = editor.__currentlyDisabled || [];
+
+	if (!editor.ui.view.toolbar) {
+		return [];
+	}
+
+	return editor.ui.view.toolbar.items._items;
+}
+
+export function disableItems(editor, except) {
+	jQuery.each(getToolbarItems(editor), function(index, item) {
+		let toDisable = item;
+
+		if (item instanceof FileDialogButtonView) {
+			toDisable = item.buttonView;
+		} else if (item === except || !item.hasOwnProperty('isEnabled')) {
+			toDisable = null;
+		}
+
+		if (!toDisable) {
+			// do nothing
+		} else if (toDisable.isEnabled) {
+			toDisable.isEnabled = false;
+		} else {
+			editor.__currentlyDisabled.push(toDisable);
+		}
+	});
+}
+
+export function enableItems(editor) {
+	jQuery.each(getToolbarItems(editor), function(index, item) {
+		let toEnable = item;
+
+		if (item instanceof FileDialogButtonView) {
+			toEnable = item.buttonView;
+		}
+
+		if (editor.__currentlyDisabled.indexOf(toEnable) < 0) {
+			toEnable.isEnabled = true
+		}
+	});
+
+	editor.__currentlyDisabled = [];
+}

--- a/src/icons/source.svg
+++ b/src/icons/source.svg
@@ -11,7 +11,7 @@
    viewBox="0 0 20 20"
    version="1.1"
    id="svg10"
-   sodipodi:docname="code-block.svg"
+   sodipodi:docname="source.svg"
    inkscape:version="0.92.3 (2405546, 2018-03-11)">
   <defs
      id="defs14" />
@@ -34,26 +34,23 @@
      inkscape:current-layer="svg10" />
   <g
      id="g8"
-     style="fill:none;fill-rule:evenodd"
-     transform="matrix(0.8751128,0,0,0.8751128,1.3360704,0.91121972)">
+     style="fill:#000000;fill-rule:evenodd"
+     transform="matrix(0.8751128,0,0,0.8751128,4.2423992,5.525391)">
     <g
        id="g6"
-       style="fill:#353535">
+       style="fill:#000000">
       <g
          transform="translate(2,5.6)"
-         id="g4">
+         id="g4"
+         style="fill:#000000">
         <path
            d="M 10.5,0.1 15.7,4 v 1.3 l -5.6,4 C 10,9.5 9.8,9.5 9.6,9.5 9.3,9.4 9,8.8 9,8.5 L 9.3,8.1 14,4.6 9.5,1.4 9.3,1.2 C 9.2,0.9 9.2,0.6 9.3,0.4 9.5,0.2 9.8,0 10.1,0 a 0.8,0.8 0 0 1 0.4,0.1 z M 5.3,0.1 0,4 v 1.3 l 5.6,4 C 5.7,9.5 5.9,9.5 6.1,9.5 6.4,9.4 6.8,8.8 6.7,8.5 6.7,8.4 6.7,8.2 6.5,8.1 L 1.5,4.6 6.2,1.4 6.4,1.2 C 6.5,0.9 6.5,0.6 6.4,0.4 6.2,0.2 5.9,0 5.6,0 A 0.8,0.8 0 0 0 5.3,0.1 Z"
            id="path2"
-           inkscape:connector-curvature="0" />
+           inkscape:connector-curvature="0"
+           style="fill:#000000" />
       </g>
     </g>
   </g>
-  <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.09228408;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     d="M 0.22004104,0.22004104 V 0.76600468 19.779959 H 19.779959 V 0.22004104 Z M 1.3119682,1.3119682 H 18.688032 V 18.688032 H 1.3119682 Z"
-     id="rect3722"
-     inkscape:connector-curvature="0" />
   <metadata
      id="metadata4596">
     <rdf:RDF>
@@ -66,4 +63,9 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <path
+     style="stroke-width:0.0390625"
+     d="M 1.2772336,0.02277222 V 20.022772 H 6.2381712 V 18.225897 H 3.0741087 V 1.8196472 h 8.2031253 l 3.554687,3.59375 v 3.5546875 h 1.796875 V 4.6712097 L 12.019421,0.02277222 Z"
+     id="path2-3"
+     inkscape:connector-curvature="0" />
 </svg>

--- a/src/icons/wysiwyg.svg
+++ b/src/icons/wysiwyg.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 512 512"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="wysiwyg.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="1.3037281"
+     inkscape:cx="252.52639"
+     inkscape:cy="155.86537"
+     inkscape:current-layer="svg4" />
+  <path
+     d="m 166.9714,230.61312 h 185 v 31 h -185 z m 1,-61 h 185 v 32 h -185 z m 0,-61 h 185 v 32 h -185 z m 289,5 -118,-118.0000009 H 63.971404 V 507.61312 H 457.9714 v -394 z m -347,348 V 41.613119 h 210 l 92,92.000001 v 328 z"
+     id="path2"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccccccccccccccccccc" />
+  <rect
+     style="fill:#000000;fill-opacity:1;stroke:#353535;stroke-opacity:1"
+     id="rect832"
+     width="184.08746"
+     height="112.75357"
+     x="169.51387"
+     y="313.33896" />
+</svg>

--- a/src/op-ckeditor.js
+++ b/src/op-ckeditor.js
@@ -35,7 +35,8 @@ FullEditor.defaultConfig.toolbar = {
 			'redo',
 			'openProjectShowFormattingHelp',
 			'|',
-			'preview'
+			'preview',
+			'opShowSource'
 		]
 };
 
@@ -56,6 +57,7 @@ ConstrainedEditor.defaultConfig.toolbar = {
 		'blockQuote',
 		'|',
 		'openProjectShowFormattingHelp',
-		'preview'
+		'preview',
+		'opShowSource'
 	]
 };

--- a/src/op-plugins.js
+++ b/src/op-plugins.js
@@ -33,6 +33,7 @@ import OPMacroListPlugin from "./plugins/op-macro-list-plugin";
 import OPAttachmentListenerPlugin from './plugins/op-attachment-listener-plugin';
 import OpImageAttachmentLookup from './plugins/op-image-attachment-lookup/op-image-attachment-lookup-plugin';
 import CommonMark from './commonmark/commonmark';
+import OPSourceCodePlugin from './plugins/op-source-code.plugin';
 
 // We divide our plugins into separate concerns here
 // in order to enable / disable each group by configuration
@@ -78,6 +79,7 @@ export const builtinPlugins = [
 	OPHelpLinkPlugin,
 	CodeBlockPlugin,
 	OPPreviewPlugin,
+	OPSourceCodePlugin,
 
 
 	CommonMark,

--- a/src/plugins/op-preview.plugin.js
+++ b/src/plugins/op-preview.plugin.js
@@ -5,8 +5,8 @@ import imageIcon from '../icons/preview.svg';
 import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
-import FileDialogButtonView from '@ckeditor/ckeditor5-upload/src/ui/filedialogbuttonview';
 import {getOPPath, getOPPreviewContext, getOPService} from './op-context/op-context';
+import {enableItems, disableItems} from '../helpers/button-disabler';
 
 export default class OPPreviewPlugin extends Plugin {
 
@@ -18,7 +18,6 @@ export default class OPPreviewPlugin extends Plugin {
 		const editor = this.editor;
 		let previewing = false;
 		let unregisterPreview = null;
-		let currentlyDisabled = [];
 
 		editor.ui.componentFactory.add( 'preview', locale => {
 			const view = new ButtonView( locale );
@@ -29,49 +28,6 @@ export default class OPPreviewPlugin extends Plugin {
 				tooltip: true,
 			} );
 
-			let toolbarItems = function() {
-				if (!editor.ui.view.toolbar) {
-					return [];
-				}
-
-				return editor.ui.view.toolbar.items._items;
-			};
-
-			let disableItems = function() {
-				jQuery.each(toolbarItems(), function(index, item) {
-					let toDisable = item;
-
-					if (item instanceof FileDialogButtonView) {
-						toDisable = item.buttonView;
-					} else if (item === view || !item.hasOwnProperty('isEnabled')) {
-						toDisable = null;
-					}
-
-					if (!toDisable) {
-						// do nothing
-					} else if (toDisable.isEnabled) {
-						toDisable.isEnabled = false;
-					} else {
-						currentlyDisabled.push(toDisable);
-					}
-				});
-			};
-
-			let enableItems = function() {
-				jQuery.each(toolbarItems(), function(index, item) {
-					let toEnable = item;
-
-					if (item instanceof FileDialogButtonView) {
-						toEnable = item.buttonView;
-					}
-
-					if (currentlyDisabled.indexOf(toEnable) < 0) {
-						toEnable.isEnabled = true
-					}
-				});
-
-				currentlyDisabled.length = 0;
-			};
 
 			let showPreview = function(preview) {
 				let $editable = jQuery(editor.element);
@@ -93,7 +49,7 @@ export default class OPPreviewPlugin extends Plugin {
 				$reference.hide();
 				$reference.after($previewWrapper);
 
-				disableItems();
+				disableItems(editor, view);
 			};
 
 			let getAndShowPreview = function() {
@@ -118,7 +74,7 @@ export default class OPPreviewPlugin extends Plugin {
 				$mainEditor.siblings('.ck-editor__preview').remove();
 				$mainEditor.show();
 
-				enableItems();
+				enableItems(editor);
 			};
 
 

--- a/src/plugins/op-source-code.plugin.js
+++ b/src/plugins/op-source-code.plugin.js
@@ -1,0 +1,103 @@
+// This SVG file import will be handled by webpack's raw-text loader.
+// This means that imageIcon will hold the source SVG.
+import sourceIcon from '../icons/source.svg';
+import wysiwygIcon from '../icons/wysiwyg.svg';
+
+import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
+
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import {getOPPath, getOPPreviewContext, getOPService} from './op-context/op-context';
+import {enableItems, disableItems} from '../helpers/button-disabler';
+
+export default class OPSourceCodePlugin extends Plugin {
+
+	static get pluginName() {
+		return 'OPSourceCode';
+	}
+
+	init() {
+		const editor = this.editor;
+		let inSourceMode = false;
+		let labels = {
+			source: window.I18n.t('js.editor.mode.manual'),
+			wysiwyg: window.I18n.t('js.editor.mode.wysiwyg'),
+		}
+
+
+		editor.ui.componentFactory.add( 'opShowSource', locale => {
+			const view = new ButtonView( locale );
+
+			view.set( {
+				label: labels.source,
+				class: '',
+				icon: sourceIcon,
+				tooltip: true,
+			} );
+
+
+			let showSource = function(preview) {
+				let $editable = jQuery(editor.element);
+				let $mainEditor = $editable.find('.ck-editor__main');
+				let $reference;
+
+				if ($mainEditor.length) {
+					$reference = $mainEditor;
+				} else {
+					$reference = $editable;
+				}
+
+				let $sourceWrapper = jQuery('<div class="ck-editor__source"></div>');
+				$reference.siblings('.ck-editor__source').remove();
+
+				$reference.hide();
+				$reference.after($sourceWrapper);
+
+				disableItems(editor, view);
+
+				editor.fire('op:source-code-enabled');
+
+				view.set( {
+					label: labels.wysiwyg,
+					class: '-source-enabled',
+					icon: wysiwygIcon,
+					tooltip: true,
+				} );
+
+			};
+
+			let hideSource = function() {
+				let $editable = jQuery(editor.element);
+				let $mainEditor = $editable.find('.ck-editor__main');
+
+				editor.fire('op:source-code-disabled');
+
+				$mainEditor.siblings('.ck-editor__source').remove();
+				$mainEditor.show();
+
+				enableItems(editor);
+
+				view.set( {
+					label: labels.source,
+					class: '',
+					icon: sourceIcon,
+					tooltip: true,
+				} );
+			};
+
+
+			// Callback executed once the image is clicked.
+			view.on('execute', () => {
+				if (inSourceMode) {
+					inSourceMode = false;
+					hideSource();
+				} else {
+					inSourceMode = true;
+					showSource();
+				}
+			});
+
+			return view;
+		} );
+	}
+
+}


### PR DESCRIPTION
Extracts the disabling of buttons from preview plugin into a common helper and adds a markdown button

https://github.com/opf/openproject/pull/6701