### PR TITLE
Fix nested checkboxes due to different label/link positioning

### DIFF
--- a/src/commonmark/commonmarkdataprocessor.js
+++ b/src/commonmark/commonmarkdataprocessor.js
@@ -97,14 +97,19 @@ export default class CommonMarkDataProcessor {
 		// Replace todolist with markdown representation
 		turndownService.addRule('todolist', {
 			filter: function (node) {
-				let parent = node.parentNode;
-				let grandparent = parent && parent.parentNode;
-
-				return node.type === 'checkbox' &&
-					grandparent && grandparent.nodeName === 'LI';
+				// check if we're a todo list item
+				return node.nodeName === 'LI' && node.closest('ul.todo-list');
 			  },
-			  replacement: function (content, node) {
-				return (node.checked ? '[x]' : '[ ]') + ' '
+			  replacement: function (content, node, options) {
+				content = content
+					.replace(/^\n+/, '') // remove leading newlines
+					.replace(/\n+$/, '\n') // replace trailing newlines with just a single one
+					.replace(/\n/gm, '\n    ') // indent
+
+				var prefix = options.bulletListMarker + '   ';
+				var input = node.querySelector('input[type=checkbox]');
+				var tasklist = (input && input.checked) ? '[x] ' : '[ ] ';
+				return prefix + tasklist + content + (node.nextSibling && !/\n$/.test(content) ? '\n' : '');
 			  }
 		});
 


### PR DESCRIPTION
CKEditor converts todo lists differently when they contain a link

```
<ul class="todo-list">
  <li>
    <label class="todo-list__label">
      <input type="checkbox" disabled="disabled" checked="checked">
      <span  class="todo-list__label__description">4 teaspoons baking powder&nbsp;</span>
    </label>
  </li>
  <li>
    <a href="https://example.com">
      <label class="todo-list__label"><input type="checkbox" disabled="disabled">
        <span class="todo-list__label__description">1/4 teaspoon salt&nbsp;</span>
      </label>
    </a>
  </li>
</ul>
```

which is why we need to override the list item rule for turndown to
address this and replace the todo list on our own.