### PR TITLE
Update paths to the frontend location

### DIFF
--- a/bin/dist.sh
+++ b/bin/dist.sh
@@ -4,10 +4,10 @@
 
 echo "Replacing current vendored build...\n"
 # Unlink previous symlinks or files if any
-unlink "${OPENPROJECT_CORE}/app/assets/javascripts/vendor/ckeditor/ckeditor.js" || true
-unlink "${OPENPROJECT_CORE}/app/assets/javascripts/vendor/ckeditor/ckeditor.js.map" || true
+unlink "${OPENPROJECT_CORE}/frontend/src/vendor/ckeditor/ckeditor.js" || true
+unlink "${OPENPROJECT_CORE}/frontend/src/vendor/ckeditor/ckeditor.js.map" || true
 
-cp build/ckeditor.js "${OPENPROJECT_CORE}/app/assets/javascripts/vendor/ckeditor/ckeditor.js"
-cp build/ckeditor.js.map "${OPENPROJECT_CORE}/app/assets/javascripts/vendor/ckeditor/ckeditor.js.map"
+cp build/ckeditor.js "${OPENPROJECT_CORE}/frontend/src/vendor/ckeditor/ckeditor.js"
+cp build/ckeditor.js.map "${OPENPROJECT_CORE}/frontend/src/vendor/ckeditor/ckeditor.js.map"
 
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "build": "NODE_ENV=production ./node_modules/.bin/webpack --mode production",
     "postbuild": "sh bin/dist.sh",
     "preversion": "npm run build; if [ -n \"$(git status src/ckeditor.js build/ --porcelain)\" ]; then git add -u src/ckeditor.js build/ && git commit -m 'Internal: Build.'; fi",
-    "prewatch-and-link": "ln -sf `pwd`/build/ckeditor.js `echo $OPENPROJECT_CORE`/app/assets/javascripts/vendor/ckeditor/ckeditor.js && ln -sf `pwd`/build/ckeditor.js.map `echo $OPENPROJECT_CORE`/app/assets/javascripts/vendor/ckeditor/ckeditor.js.map",
+    "prewatch-and-link": "ln -sf `pwd`/build/ckeditor.js `echo $OPENPROJECT_CORE`/frontend/src/vendor/ckeditor/ckeditor.js && ln -sf `pwd`/build/ckeditor.js.map `echo $OPENPROJECT_CORE`/frontend/src/vendor/ckeditor/ckeditor.js.map",
     "watch": "npm run watch-and-link",
     "watch-and-link": "NODE_ENV=development ./node_modules/.bin/webpack --display-error-details --watch --colors --cache --debug"
   },


### PR DESCRIPTION
The core moved the vendor ckeditor bundle to the frontend for dynamically importing it. This updates the build tools to correctly use these paths

Belongs to https://github.com/opf/openproject/pull/8482