### PR TITLE
Handling corrupted mentions

### DIFF
--- a/src/mentions/mentions-caster.js
+++ b/src/mentions/mentions-caster.js
@@ -20,40 +20,62 @@ export function MentionCaster( editor ) {
 		}
 	});
 
-	// The upcast converter will convert <mention data-id...></mention> elements
-	// on the input HTML data to the model 'mention' attribute.
+	// The upcast converter will convert <mention data-id="id" data-type="type" data-text="text">text</mention>
+	// elements on the input HTML data to the model 'mention' attribute.
+	editor.conversion
+		.for( 'upcast' )
+		.elementToAttribute( {
+			view: {
+				name: 'mention',
+				key: 'data-mention',
+				classes: 'mention',
+			},
+			model: {
+				key: 'mention',
+				value: viewItem => {
+					const idNumber = viewItem.getAttribute( 'data-id' );
+					const type = viewItem.getAttribute( 'data-type' );
+					const text = viewItem.getAttribute( 'data-text' );
+					const link = getMentionLink(idNumber, type);
+					// The mention feature expects that the mention attribute value
+					// in the model is a plain object with a set of additional attributes.
+					// In order to create a proper object use the toMentionAttribute() helper method:
+					const mentionAttribute = editor.plugins.get( 'Mention' ).toMentionAttribute( viewItem, {
+						// Pass the properties we'll need for the editing and data downcast.
+						idNumber,
+						link,
+						text,
+						type,
+					} );
+
+					return mentionAttribute;
+				}
+			},
+			converterPriority: 'high'
+		} );
+
+	// Handle mysterious corrupted mentions (<span class="mention" data-type="">${@user or #wp id}</span>)
 	editor.conversion
 		.for( 'upcast' )
 		.elementToAttribute( {
 		view: {
-			name: 'mention',
+			name: 'span',
 			key: 'data-mention',
 			classes: 'mention',
 		},
 		model: {
 			key: 'mention',
 			value: viewItem => {
-				const id = viewItem.getAttribute( 'data-id' );
-				const text = viewItem.getAttribute( 'data-text' );
-				const type = viewItem.getAttribute( 'data-type' );
-				const typesPathMap = {
-					user: pluginContext.services.apiV3Service[`${type}s`].segment,
-					group: `admin/${pluginContext.services.apiV3Service[`${type}s`].segment}`,
-				}
-				const base = window.OpenProject.urlRoot;
-				const link = `${base}/${typesPathMap[type]}/${id}`;
-				// The mention feature expects that the mention attribute value
-				// in the model is a plain object with a set of additional attributes.
-				// In order to create a proper object use the toMentionAttribute() helper method:
-				const mentionAttribute = editor.plugins.get( 'Mention' ).toMentionAttribute( viewItem, {
-					// Pass the properties we'll need for the editing and data downcast.
-					id,
-					link,
-					text,
-					type,
-				} );
+				const children = [...viewItem.getChildren()];
+				const content = children[0];
+				const text = content && content.data;
 
-				return mentionAttribute;
+				if (text) {
+					const errorMessage = `[Invalid mention: ${text}]`;
+					content._data = errorMessage;
+				}
+
+				return;
 			}
 		},
 		converterPriority: 'high'
@@ -75,9 +97,7 @@ export function MentionCaster( editor ) {
 					{
 						'class': 'mention',
 						'href': modelAttributeValue.link,
-						'data-mention': modelAttributeValue.id.startsWith('@') ?
-											modelAttributeValue.id :
-											`@${modelAttributeValue.id}`,
+						'data-mention': modelAttributeValue.text,
 						'title': modelAttributeValue.text,
 					}
 				);
@@ -101,7 +121,7 @@ export function MentionCaster( editor ) {
 					'mention',
 					{
 						'class': 'mention',
-						'data-id': modelAttributeValue.id.replace('@', ''),
+						'data-id': modelAttributeValue.idNumber,
 						'data-type': modelAttributeValue.type,
 						'data-text': modelAttributeValue.text,
 					}
@@ -110,4 +130,12 @@ export function MentionCaster( editor ) {
 				return element;
 			}
 		});
+
+	function getMentionLink(id, type) {
+		const typePathBase = pluginContext.services.apiV3Service[`${type}s`].segment;
+		const typePath = type === 'group' ? `admin/${typePathBase}` : typePathBase;
+		const base = window.OpenProject.urlRoot;
+
+		return `${base}/${typePath}/${id}`;
+	}
 }

--- a/src/mentions/user-mentions.js
+++ b/src/mentions/user-mentions.js
@@ -21,14 +21,15 @@ export function userMentions(queryText) {
 					const type = mention._type.toLowerCase();
 					const text = `@${mention.name}`;
 					const id = `@${mention.id}`;
+					const idNumber = mention.id;
 					const typesPathMap = {
 						user: pluginContext.services.apiV3Service[`${type}s`].segment,
 						group: `admin/${pluginContext.services.apiV3Service[`${type}s`].segment}`,
 					}
 					const typeSegment = typesPathMap[type];
-					const link = `${base}/${typeSegment}/${mention.id}`;
+					const link = `${base}/${typeSegment}/${idNumber}`;
 
-					return { type, id, text, link, name: mention.name };
+					return { type, id, text, link, idNumber, name: mention.name };
 				}));
 			});
 		})

--- a/src/mentions/work-package-mentions.js
+++ b/src/mentions/work-package-mentions.js
@@ -9,7 +9,9 @@ export function workPackageMentions(query) {
 			.getJSON(url, {q: query, scope: 'all'}, collection => {
 				resolve(collection.map(wp => {
 					const id = `#${wp.id}`;
-					return { type: 'work_package', id: id, text: id, name: wp.to_s, link: base + wp.id };
+					const idNumber = wp.id;
+
+					return { id, idNumber, type: 'work_package', text: id, name: wp.to_s, link: base + wp.id };
 				}));
 			});
 		})


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/35786

This pull request:

- [x] Handles corrupted mentions (e.g., <span class="mention" data-type="">user#89</span>) by inserting an error message instead of the mention.

**Notes**
To test, switch the editor to markdown mode, paste <span class="mention" data-type="">user#89</span>, and switch back to the editing mode. 