### PR TITLE
[#33857] escape non-breaking space characters

### DIFF
--- a/src/commonmark/commonmarkdataprocessor.js
+++ b/src/commonmark/commonmarkdataprocessor.js
@@ -189,6 +189,8 @@ export default class CommonMarkDataProcessor {
 			replacement: ( _content, node ) => node.outerHTML,
 		});
 
-		return turndownService.turndown( domFragment );
+		let turndown = turndownService.turndown( domFragment );
+		// Escape non-breaking space characters
+		return turndown.replace(/\u00A0/, '&nbsp;');
 	}
 }


### PR DESCRIPTION
[#33857](https://community.openproject.org/wp/33857)

### WAT?

- before storing the markdown into the database we escape `NBSP` characters

⚠️ Merge together with https://github.com/opf/openproject/pull/14868