### PR TITLE
Skip adding custom classes when not finding listElement

### DIFF
--- a/src/plugins/op-custom-css-classes-plugin.js
+++ b/src/plugins/op-custom-css-classes-plugin.js
@@ -296,6 +296,12 @@ export default class OpCustomCssClassesPlugin extends Plugin {
 	_manageListItems(viewWriter, modelElement, viewElement, viewElements, config) {
 		const listItemElement = viewElement.findAncestor('li');
 		const listElement = viewElement.findAncestor(/^(ul|ol)$/);
+
+
+		if (!listElement) {
+			return viewElements;
+		}
+
 		const listType = modelElement.getAttribute('listType');
 		const listTypeClass = config.attributesWithCustomClassesMap[listType];
 		const previousElement = listElement.previousSibling;


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/56053/activity

https://github.com/opf/commonmark-ckeditor-build/pull/92/files#diff-2d17d85890bc343e1cbc1b46a1f02eaf670c00a9d7d0fa13fdbb126171873a8bR307 might be causing the error, even though we should only enter this branch in case of a list