### PR TITLE
[#61465] show hover cards within mentions

### DIFF
--- a/src/mentions/mentions-item-renderer.js
+++ b/src/mentions/mentions-item-renderer.js
@@ -1,6 +1,11 @@
 export function customItemRenderer( item ) {
     const itemElement = document.createElement( 'span' );
 
+	if (item.type === 'user' || item.type === 'work_package') {
+		itemElement.setAttribute('data-hover-card-trigger-target', 'trigger');
+		itemElement.setAttribute('data-hover-card-url', `${item.link}/hover_card`);
+	}
+
 	itemElement.classList.add( 'mention-list-item' );
 	itemElement.textContent = item.name;
 


### PR DESCRIPTION
Works for both users and work packages.

The proposal list popping up when typing a `@` or `#` in an editor field will now also show a hover card when you hover over it.

Please see [oprenproject#18034](https://github.com/opf/openproject/pull/18034) for the main repo changes. That PR also contains two other bug fixes regrading hover cards.