### PR TITLE
Allow `Activity::Comment` to be mentionable

### DIFF
--- a/src/mentions/user-mentions.js
+++ b/src/mentions/user-mentions.js
@@ -6,7 +6,14 @@ import {
 
 export function userMentions(queryText) {
 	const editor = this;
-	const resource = getOPResource(editor);
+	let resource = getOPResource(editor);
+
+	if (resource && resource._type === 'Activity::Comment') {
+		const workPackage = resource.$embedded.workPackage;
+		if (workPackage) {
+			resource = workPackage;
+		}
+	}
 
 	// Unsupported context does not allow mentioning
 	if (!(resource && resource._type === 'WorkPackage')) {


### PR DESCRIPTION
Derive the work package resource from the `Activity::Comment` so that it\'s is mentionable.

https://community.openproject.org/work_packages/62363

https://github.com/opf/openproject/pull/18537


_This is an intermediate solution, discuss with devs on longer term solution if mentions want to be enabled in other resources such as Meetings._ https://community.openproject.org/meetings/4863#item-11906