### PR TITLE
[#69553] Remove jQuery from CKEditor build [FIXUP]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 - Removed jQuery dependency from the CKEditor build. All jQuery usage has been replaced with vanilla JavaScript equivalents:
   - `jQuery.each()` replaced with native `Array.forEach()`
-  - `jQuery.getJSON()` replaced with `fetch()` API
-  - `jQuery.ajax()` replaced with `fetch()` API
+  - `jQuery.getJSON()` replaced with Request.JS
+  - `jQuery.ajax()` replaced with Request.JS
   - jQuery DOM manipulation replaced with native DOM APIs (`document.createElement()`, `element.parentElement`, `element.style`, etc.)
 
 ### Migration Notes

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Now the webpack development mode is building the files and outputting them to `a
 
 ### jQuery Removal
 
-As of version 11.2.0, this library no longer uses jQuery internally. All jQuery dependencies have been replaced with vanilla JavaScript equivalents using the Fetch API and native DOM manipulation.
+As of version 11.2.0, this library no longer uses jQuery internally. All jQuery dependencies have been replaced with vanilla JavaScript equivalents using Request.JS and native DOM manipulation.
 
 **Important for downstream consumers (e.g., OpenProject):** While this library no longer uses jQuery internally, downstream applications should continue to expose the jQuery global if other parts of the application depend on it. Do not remove the jQuery global from the downstream application (OpenProject) yet until all components have been migrated.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@ckeditor/ckeditor5-watchdog": "44.3.0",
         "@ckeditor/ckeditor5-widget": "44.3.0",
         "@eslint/js": "^9.16.0",
+        "@rails/request.js": "^0.0.13",
         "babel-jest": "^29.7.0",
         "css-loader": "^7.1.2",
         "eslint": "^9.23.0",
@@ -76,6 +77,9 @@
       "engines": {
         "node": ">=6.9.0",
         "npm": ">=3.0.0"
+      },
+      "peerDependencies": {
+        "@rails/request.js": "^0.0.13"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -131,6 +135,7 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -4045,6 +4050,13 @@
       "integrity": "sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==",
       "dev": true
     },
+    "node_modules/@rails/request.js": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@rails/request.js/-/request.js-0.0.13.tgz",
+      "integrity": "sha512-7MXmjFOPuaxpjG8brqKJG0EfIe9ak6R0wRnjCBtRuADNFbdlRxETdKx1T5NVU4Ato3iZOkEpeSUEuLboL3tCGA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -4692,6 +4704,7 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4761,6 +4774,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5242,6 +5256,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -8608,6 +8623,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9304,6 +9320,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
       "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
       "dev": true,
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -10970,6 +10987,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -11446,6 +11464,7 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -12343,6 +12362,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -13529,6 +13549,7 @@
       "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -14322,6 +14343,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -17122,6 +17144,12 @@
       "integrity": "sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==",
       "dev": true
     },
+    "@rails/request.js": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@rails/request.js/-/request.js-0.0.13.tgz",
+      "integrity": "sha512-7MXmjFOPuaxpjG8brqKJG0EfIe9ak6R0wRnjCBtRuADNFbdlRxETdKx1T5NVU4Ato3iZOkEpeSUEuLboL3tCGA==",
+      "dev": true
+    },
     "@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -17648,7 +17676,8 @@
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-globals": {
       "version": "7.0.1",
@@ -17700,6 +17729,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -18034,6 +18064,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
       "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -20345,6 +20376,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -20872,7 +20904,8 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
       "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -22068,6 +22101,7 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
       "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -22319,6 +22353,7 @@
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
           "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
           "dev": true,
+          "peer": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -22903,6 +22938,7 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "dev": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -23734,6 +23770,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
       "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@ckeditor/ckeditor5-watchdog": "44.3.0",
     "@ckeditor/ckeditor5-widget": "44.3.0",
     "@eslint/js": "^9.16.0",
+    "@rails/request.js": "^0.0.13",
     "babel-jest": "^29.7.0",
     "css-loader": "^7.1.2",
     "eslint": "^9.23.0",
@@ -98,5 +99,8 @@
   },
   "dependencies": {
     "patch-package": "^8.0.0"
+  },
+  "peerDependencies": {
+    "@rails/request.js": "^0.0.13"
   }
 }

--- a/src/mentions/user-mentions.js
+++ b/src/mentions/user-mentions.js
@@ -3,6 +3,7 @@ import {
 	getOPPath,
 	getPluginContext,
 } from "../plugins/op-context/op-context";
+import { get } from '@rails/request.js';
 
 export function userMentions(queryText) {
 	const editor = this;
@@ -24,18 +25,13 @@ export function userMentions(queryText) {
 		return [];
 	}
 
-	const url = getOPPath(editor).api.v3.principals(resource, queryText) + '&select=elements/_type,elements/id,elements/name';
+	const url = getOPPath(editor).api.v3.principals(resource, queryText);
 	const pluginContext = getPluginContext(editor);
 	const base = window.OpenProject.urlRoot;
 
 	return new Promise((resolve, reject) => {
-		fetch(url)
-			.then(response => {
-				if (!response.ok) {
-					throw new Error(`HTTP error! status: ${response.status}`);
-				}
-				return response.json();
-			})
+		get(url, { responseKind: 'json', query: { select: 'elements/_type,elements/id,elements/name' } })
+			.then(response => response.json)
 			.then(collection => {
 				resolve(_.uniqBy(collection._embedded.elements, (el) => el.id).map(mention => {
 					const type = mention._type.toLowerCase();

--- a/src/mentions/work-package-mentions.js
+++ b/src/mentions/work-package-mentions.js
@@ -1,3 +1,5 @@
+import { get } from '@rails/request.js';
+
 export function workPackageMentions(prefix) {
   return function (query) {
     let editor = this;
@@ -9,14 +11,8 @@ export function workPackageMentions(prefix) {
     }
 
     return new Promise((resolve, reject) => {
-      const params = new URLSearchParams({ q: query, scope: "all" });
-      fetch(`${url}?${params.toString()}`)
-        .then(response => {
-          if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
-          }
-          return response.json();
-        })
+      get(url, { responseKind: 'json', query: { q: query, scope: "all" } })
+        .then(response => response.json)
         .then(collection => {
           resolve(collection.map(wp => {
             const id = `${prefix}${wp.id}`;

--- a/src/plugins/op-preview.plugin.js
+++ b/src/plugins/op-preview.plugin.js
@@ -7,6 +7,7 @@ import { ButtonView } from '@ckeditor/ckeditor5-ui';
 import { Plugin } from '@ckeditor/ckeditor5-core';
 import {getOPPath, getOPPreviewContext, getOPService} from './op-context/op-context';
 import {enableItems, disableItems} from '../helpers/button-disabler';
+import { post } from '@rails/request.js';
 
 export default class OPPreviewPlugin extends Plugin {
 
@@ -39,7 +40,7 @@ export default class OPPreviewPlugin extends Plugin {
 
 				const previewWrapper = document.createElement('div');
 				previewWrapper.className = 'ck-editor__preview op-uc-container';
-				
+
 				// Remove existing preview elements (only direct siblings)
 				const existingPreviews = Array.from(reference.parentElement.children)
 					.filter(el => el !== reference && el.classList.contains('ck-editor__preview'));
@@ -58,19 +59,12 @@ export default class OPPreviewPlugin extends Plugin {
 				let link = getOPPreviewContext(editor);
 				let url = getOPPath(editor).api.v3.previewMarkup(link);
 
-				fetch(url, {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'text/plain; charset=UTF-8'
-					},
-					body: editor.getData()
+				post(url, {
+					contentType: 'text/plain; charset=UTF-8',
+					responseKind: 'html',
+					body: editor.getData(),
 				})
-					.then(response => {
-						if (!response.ok) {
-							throw new Error(`HTTP error! status: ${response.status}`);
-						}
-						return response.text();
-					})
+					.then(response => response.html)
 					.then(showPreview)
 					.catch(error => {
 						console.error('Error fetching preview:', error);
@@ -90,12 +84,12 @@ export default class OPPreviewPlugin extends Plugin {
 				if (unregisterPreview) {
 					unregisterPreview();
 				}
-				
+
 				// Remove existing preview elements (only direct siblings)
 				const existingPreviews = Array.from(mainEditor.parentElement.children)
 					.filter(el => el !== mainEditor && el.classList.contains('ck-editor__preview'));
 				existingPreviews.forEach(el => el.remove());
-				
+
 				mainEditor.style.display = '';
 
 				enableItems(editor);


### PR DESCRIPTION
> [!IMPORTANT]
> Follow on from #107  

# Ticket

https://community.openproject.org/wp/69553

# What are you trying to accomplish?

Fixes broken mentions (work package, user) and previews.

In detail:

- Adds Request.js as peer/dev dependency
- Replaces fetch() calls with Request.JS

# What approach did you choose and why?

I went with [Rails Request.JS](https://github.com/rails/request.js) as we are already using it in core. It takes care of setting `X-CSRF-Token` headers automatically.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
