### PR TITLE
Render work-package mentions with semantic identifiers

### DIFF
--- a/src/commonmark/commonmarkdataprocessor.js
+++ b/src/commonmark/commonmarkdataprocessor.js
@@ -23,6 +23,10 @@ import { getOPPath } from "../plugins/op-context/op-context";
 
 export const originalSrcAttribute = 'data-original-src';
 
+// `#` / `##` / `###` followed by either a numeric id (`6217`) or a
+// semantic identifier (`PROJ-7`, `MY_PROJ-1`, `MACROPROJ-42`). The
+// trailing `(?!\w)` rejects mid-word continuations like `#PROJ-1abc`.
+// Group 1 is the marker, group 2 is the id.
 const WP_REF_RE = /^(#{1,3})(\d+|[A-Z][A-Z0-9_]*-\d+)(?!\w)/;
 
 // Stored `<mention>X</mention>` envelopes round-trip through markdown-it

--- a/src/commonmark/commonmarkdataprocessor.js
+++ b/src/commonmark/commonmarkdataprocessor.js
@@ -23,7 +23,21 @@ import { getOPPath } from "../plugins/op-context/op-context";
 
 export const originalSrcAttribute = 'data-original-src';
 
-const WP_REF_RE = /^(#{1,3})(\d+)(?!\w)/;
+const WP_REF_RE = /^(#{1,3})(\d+|[A-Z][A-Z0-9_]*-\d+)(?!\w)/;
+
+// Stored `<mention>X</mention>` envelopes round-trip through markdown-it
+// as three independent `html_inline` tokens; `#`-leading text between
+// the open and close must not be re-promoted by this rule.
+function isInsideStoredMention(tokens) {
+	for (let i = tokens.length - 1; i >= 0; i--) {
+		const token = tokens[i];
+		if (token.type !== 'html_inline') continue;
+		const c = token.content;
+		if (c.startsWith('</mention')) return false;
+		if (c.startsWith('<mention')) return true;
+	}
+	return false;
+}
 
 function workPackageRefInlineRule(state, silent) {
 	const start = state.pos;
@@ -39,6 +53,8 @@ function workPackageRefInlineRule(state, silent) {
 	// If we are in markdown-it silent mode, don't do anything and return true.
 	if (silent) return true;
 
+	if (isInsideStoredMention(state.tokens)) return false;
+
 	const hashes = match[1].length;
 	const id = match[2];
 	const ref = match[0];
@@ -47,7 +63,7 @@ function workPackageRefInlineRule(state, silent) {
 	// ##/### results in <opce-macro-wp-quickinfo> custom element
 	const html = hashes === 1
 		? `<mention class="mention" data-id="${id}" data-type="work_package" data-text="${ref}">${ref}</mention>`
-		: `<opce-macro-wp-quickinfo data-id="${id}" data-detailed="${hashes === 3}">${ref}</opce-macro-wp-quickinfo>`;
+		: `<opce-macro-wp-quickinfo data-id="${id}" data-display-id="${id}" data-detailed="${hashes === 3}">${ref}</opce-macro-wp-quickinfo>`;
 
 	const token = state.push('html_inline', '', 0);
 	token.content = html;
@@ -341,7 +357,7 @@ export default class CommonMarkDataProcessor {
 		turndownService.addRule('workPackageQuickinfo', {
 			filter: (node) => node.nodeName === 'OPCE-MACRO-WP-QUICKINFO',
 			replacement: (_content, node) => {
-				const id = node.getAttribute('data-id') || '';
+				const id = node.getAttribute('data-display-id') || node.getAttribute('data-id') || '';
 				if (!id) return '';
 				const detailed = node.getAttribute('data-detailed') === 'true';
 				return detailed ? `###${id}` : `##${id}`;
@@ -374,8 +390,14 @@ export default class CommonMarkDataProcessor {
 				)
 			},
 			replacement: (_content, node) => {
-				// Serialize work package mentions serialize to plain #ID / ##ID / ###ID
 				if (node.getAttribute('data-type') === 'work_package') {
+					// `data-display-id` signals an autocomplete-picked or
+					// round-tripped envelope; preserve those intact.
+					// Parser-emitted single-hash shorthand has no
+					// `data-display-id` and collapses to bare markdown.
+					if (node.getAttribute('data-display-id')) {
+						return node.outerHTML;
+					}
 					return node.getAttribute('data-text') || node.textContent || '';
 				}
 				return node.outerHTML;

--- a/src/commonmark/commonmarkdataprocessor.js
+++ b/src/commonmark/commonmarkdataprocessor.js
@@ -33,6 +33,9 @@ const WP_REF_RE = /^(#{1,3})(\d+|[A-Z][A-Z0-9_]*-\d+)(?!\w)/;
 // as three independent `html_inline` tokens; `#`-leading text between
 // the open and close must not be re-promoted by this rule.
 function isInsideStoredMention(tokens) {
+	if (!tokens.some(t => t.type === 'html_inline' && t.content.startsWith('<mention'))) {
+		return false;
+	}
 	for (let i = tokens.length - 1; i >= 0; i--) {
 		const token = tokens[i];
 		if (token.type !== 'html_inline') continue;

--- a/src/mentions/mentions-caster.js
+++ b/src/mentions/mentions-caster.js
@@ -1,5 +1,6 @@
 import {getPluginContext} from "../plugins/op-context/op-context";
 import { ClickObserver } from '@ckeditor/ckeditor5-engine';
+import { isWorkPackageQuickinfoMention } from '../plugins/op-macro-wp-quickinfo/predicate';
 
 export function MentionCaster( editor ) {
 	const pluginContext = getPluginContext(editor);
@@ -32,22 +33,29 @@ export function MentionCaster( editor ) {
 			model: {
 				key: 'mention',
 				value: viewItem => {
-					const idNumber = viewItem.getAttribute( 'data-id' );
+					const dataId = viewItem.getAttribute( 'data-id' );
+					const dataDisplayId = viewItem.getAttribute( 'data-display-id' );
 					const type = viewItem.getAttribute( 'data-type' );
 					const text = viewItem.getAttribute( 'data-text' );
-					const link = getMentionLink(idNumber, type);
-					// The mention feature expects that the mention attribute value
-					// in the model is a plain object with a set of additional attributes.
-					// In order to create a proper object use the toMentionAttribute() helper method:
-					const mentionAttribute = editor.plugins.get( 'Mention' ).toMentionAttribute( viewItem, {
-						// Pass the properties we'll need for the editing and data downcast.
-						idNumber,
+
+					// Multi-hash work-package mentions are routed to the
+					// quickinfo widget model (`op-macro-wp-quickinfo`) by
+					// that plugin's upcast. Returning `null` here keeps the
+					// mention attribute off the text node so the widget
+					// model is the sole representation.
+					if (isWorkPackageQuickinfoMention(viewItem)) {
+						return null;
+					}
+
+					const link = getMentionLink( dataDisplayId || dataId, type );
+
+					return editor.plugins.get( 'Mention' ).toMentionAttribute( viewItem, {
+						dataId,
+						dataDisplayId,
 						link,
 						text,
 						type,
 					} );
-
-					return mentionAttribute;
 				}
 			},
 			converterPriority: 'high'
@@ -124,15 +132,16 @@ export function MentionCaster( editor ) {
 					return writer.createAttributeElement('span');
 				}
 
-				const element = writer.createAttributeElement(
-					'mention',
-					{
-						'class': 'mention',
-						'data-id': modelAttributeValue.idNumber,
-						'data-type': modelAttributeValue.type,
-						'data-text': modelAttributeValue.text,
-					}
-				);
+				const attrs = {
+					'class': 'mention',
+					'data-id': modelAttributeValue.dataId,
+					'data-type': modelAttributeValue.type,
+					'data-text': modelAttributeValue.text,
+				};
+				if (modelAttributeValue.dataDisplayId) {
+					attrs['data-display-id'] = modelAttributeValue.dataDisplayId;
+				}
+				const element = writer.createAttributeElement('mention', attrs);
 
 				return element;
 			}
@@ -144,4 +153,5 @@ export function MentionCaster( editor ) {
 
 		return `${base}/${typePath}/${id}`;
 	}
+
 }

--- a/src/mentions/mentions-caster.js
+++ b/src/mentions/mentions-caster.js
@@ -47,6 +47,8 @@ export function MentionCaster( editor ) {
 						return null;
 					}
 
+					// `link` populates the editor-view `<a href>` only; the
+					// data downcast doesn't persist it.
 					const link = getMentionLink( dataDisplayId || dataId, type );
 
 					return editor.plugins.get( 'Mention' ).toMentionAttribute( viewItem, {
@@ -153,5 +155,4 @@ export function MentionCaster( editor ) {
 
 		return `${base}/${typePath}/${id}`;
 	}
-
 }

--- a/src/mentions/user-mentions.js
+++ b/src/mentions/user-mentions.js
@@ -37,11 +37,10 @@ export function userMentions(queryText) {
 					const type = mention._type.toLowerCase();
 					const text = `@${mention.name}`;
 					const id = `@${mention.id}`;
-					const idNumber = mention.id;
 					const typeSegment = pluginContext.services.apiV3Service[`${type}s`].segment;
-					const link = `${base}/${typeSegment}/${idNumber}`;
+					const link = `${base}/${typeSegment}/${mention.id}`;
 
-					return {type, id, text, link, idNumber, name: mention.name};
+					return {type, id, text, link, dataId: mention.id, name: mention.name};
 				}));
 			})
 			.catch(error => {

--- a/src/mentions/work-package-mentions.js
+++ b/src/mentions/work-package-mentions.js
@@ -3,8 +3,8 @@ import { get } from '@rails/request.js';
 export function workPackageMentions(prefix) {
   return function (query) {
     let editor = this;
-    const url = window.OpenProject.urlRoot + `/work_packages/auto_complete.json`;
-    let base = window.OpenProject.urlRoot + `/work_packages/`;
+    const urlRoot = window.OpenProject.urlRoot;
+    const url = `${urlRoot}/work_packages/auto_complete.json`;
 
     if (editor.config.get("disabledMentions").includes("work_package")) {
       return [];
@@ -16,16 +16,18 @@ export function workPackageMentions(prefix) {
         .then(collection => {
           resolve(collection.map(wp => {
             const displayId = wp.displayId || wp.id;
-            const id = `${prefix}${displayId}`;
+            const markerText = `${prefix}${displayId}`;
 
+            // CKEditor's mention feed requires `id` to start with the
+            // marker prefix; it's the model attribute and gates insertion.
             return {
-              id,
+              id: markerText,
               dataId: wp.id,
               dataDisplayId: displayId,
               type: "work_package",
-              text: id,
+              text: markerText,
               name: wp.to_s,
-              link: base + displayId,
+              link: `${urlRoot}/work_packages/${displayId}`,
             };
           }));
         })

--- a/src/mentions/work-package-mentions.js
+++ b/src/mentions/work-package-mentions.js
@@ -15,10 +15,18 @@ export function workPackageMentions(prefix) {
         .then(response => response.json)
         .then(collection => {
           resolve(collection.map(wp => {
-            const id = `${prefix}${wp.id}`;
-            const idNumber = wp.id;
+            const displayId = wp.displayId || wp.id;
+            const id = `${prefix}${displayId}`;
 
-            return { id, idNumber, type: "work_package", text: id, name: wp.to_s, link: base + wp.id };
+            return {
+              id,
+              dataId: wp.id,
+              dataDisplayId: displayId,
+              type: "work_package",
+              text: id,
+              name: wp.to_s,
+              link: base + displayId,
+            };
           }));
         })
         .catch(error => {

--- a/src/plugins/op-macro-wp-quickinfo/op-macro-wp-quickinfo-plugin.js
+++ b/src/plugins/op-macro-wp-quickinfo/op-macro-wp-quickinfo-plugin.js
@@ -72,6 +72,7 @@ export default class OPMacroWpQuickinfoPlugin extends Plugin {
 				const wpDisplayId = modelElement.getAttribute( 'wpDisplayId' ) || '';
 				const detailed = !!modelElement.getAttribute( 'detailed' );
 				const wpId = modelElement.getAttribute( 'wpId' ) || wpDisplayId;
+				const markerText = modelElement.getAttribute( 'markerText' ) || `${detailed ? '###' : '##'}${wpDisplayId}`;
 
 				const wrapper = writer.createContainerElement( 'span', {
 					class: 'op-macro-wp-quickinfo-widget',
@@ -87,7 +88,7 @@ export default class OPMacroWpQuickinfoPlugin extends Plugin {
 				);
 				writer.insert( writer.createPositionAt( wrapper, 0 ), raw );
 
-				return toWidget( wrapper, writer, { label: `#${wpDisplayId}` } );
+				return toWidget( wrapper, writer, { label: markerText } );
 			},
 		} );
 

--- a/src/plugins/op-macro-wp-quickinfo/op-macro-wp-quickinfo-plugin.js
+++ b/src/plugins/op-macro-wp-quickinfo/op-macro-wp-quickinfo-plugin.js
@@ -1,6 +1,8 @@
 import { Plugin } from '@ckeditor/ckeditor5-core';
 import { Widget, toWidget } from '@ckeditor/ckeditor5-widget';
 
+import { isWorkPackageQuickinfoMention } from './predicate';
+
 const QUICKINFO_TAG = 'opce-macro-wp-quickinfo';
 
 // Renders OpenProject's ##/### work-package quickinfo references as inline
@@ -25,26 +27,51 @@ export default class OPMacroWpQuickinfoPlugin extends Plugin {
 			allowWhere: '$text',
 			isInline: true,
 			isObject: true,
-			allowAttributes: [ 'wpId', 'detailed' ],
+			allowAttributes: [ 'wpId', 'wpDisplayId', 'detailed', 'markerText' ],
 		});
 
 		conversion.for( 'upcast' ).elementToElement( {
 			view: { name: QUICKINFO_TAG },
 			model: ( viewElement, { writer } ) => {
-				const wpId = viewElement.getAttribute( 'data-id' ) || '';
+				const dataId = viewElement.getAttribute( 'data-id' ) || '';
+				const dataDisplayId = viewElement.getAttribute( 'data-display-id' ) || '';
+				const wpDisplayId = dataDisplayId || dataId;
 				const detailed = viewElement.getAttribute( 'data-detailed' ) === 'true';
-				return writer.createElement( 'op-macro-wp-quickinfo', { wpId, detailed } );
+				const attrs = { wpDisplayId, detailed };
+				if (dataId && dataId !== wpDisplayId) {
+					attrs.wpId = dataId;
+				}
+				return writer.createElement( 'op-macro-wp-quickinfo', attrs );
 			},
 			converterPriority: 'high',
+		} );
+
+		// Reopened comments preview as widgets instead of plain links by
+		// routing stored work-package `<mention>` envelopes through the
+		// same widget model their autocomplete-picked counterparts use.
+		conversion.for( 'upcast' ).elementToElement( {
+			view: {
+				name: 'mention',
+				classes: 'mention',
+			},
+			model: ( viewElement, { writer } ) => {
+				if (!isWorkPackageQuickinfoMention(viewElement)) return null;
+				const markerText = viewElement.getAttribute( 'data-text' );
+				const detailed = markerText.startsWith('###');
+				const wpId = viewElement.getAttribute( 'data-id' ) || '';
+				const wpDisplayId = viewElement.getAttribute( 'data-display-id' ) || wpId;
+				return writer.createElement( 'op-macro-wp-quickinfo', { wpId, wpDisplayId, detailed, markerText } );
+			},
+			converterPriority: 'highest',
 		} );
 
 		conversion.for( 'editingDowncast' ).elementToElement( {
 			model: 'op-macro-wp-quickinfo',
 			view: ( modelElement, { writer } ) => {
-				const wpId = modelElement.getAttribute( 'wpId' ) || '';
+				const wpDisplayId = modelElement.getAttribute( 'wpDisplayId' ) || '';
 				const detailed = !!modelElement.getAttribute( 'detailed' );
+				const wpId = modelElement.getAttribute( 'wpId' ) || wpDisplayId;
 
-				// toWidget needs a ContainerElement, so we wrap it in a span
 				const wrapper = writer.createContainerElement( 'span', {
 					class: 'op-macro-wp-quickinfo-widget',
 				} );
@@ -52,29 +79,48 @@ export default class OPMacroWpQuickinfoPlugin extends Plugin {
 					QUICKINFO_TAG,
 					{
 						'data-id': wpId,
+						'data-display-id': wpDisplayId,
 						'data-detailed': String(detailed),
 					},
 					() => {},
 				);
 				writer.insert( writer.createPositionAt( wrapper, 0 ), raw );
 
-				return toWidget( wrapper, writer, { label: `#${wpId}` } );
+				return toWidget( wrapper, writer, { label: `#${wpDisplayId}` } );
 			},
 		} );
 
-		// Data view: include the literal ##ID / ###ID inside the element so
-		// turndown's isBlank check doesn't skip the content and parent.
 		conversion.for( 'dataDowncast' ).elementToElement( {
 			model: 'op-macro-wp-quickinfo',
 			view: ( modelElement, { writer } ) => {
-				const wpId = modelElement.getAttribute( 'wpId' ) || '';
+				const wpDisplayId = modelElement.getAttribute( 'wpDisplayId' ) || '';
 				const detailed = !!modelElement.getAttribute( 'detailed' );
+				const wpId = modelElement.getAttribute( 'wpId' );
+				const markerText = modelElement.getAttribute( 'markerText' ) || `${detailed ? '###' : '##'}${wpDisplayId}`;
+
+				// Autocomplete picks carry a `wpId`; source-typed widgets
+				// don't. Autocomplete persists as a `<mention>` envelope;
+				// the shorthand path collapses to bare markdown via turndown.
+				if (wpId) {
+					const envelope = writer.createContainerElement('mention', {
+						'class': 'mention',
+						'data-id': wpId,
+						'data-type': 'work_package',
+						'data-text': markerText,
+						'data-display-id': wpDisplayId,
+					});
+					writer.insert(writer.createPositionAt(envelope, 0), writer.createText(markerText));
+					return envelope;
+				}
+
+				// Inline the literal `##ID` / `###ID` so turndown's isBlank
+				// check doesn't skip the empty element.
 				const container = writer.createContainerElement( QUICKINFO_TAG, {
-					'data-id': wpId,
+					'data-id': wpId || wpDisplayId,
+					'data-display-id': wpDisplayId,
 					'data-detailed': String(detailed),
 				} );
-				const ref = (detailed ? '###' : '##') + wpId;
-				writer.insert( writer.createPositionAt( container, 0 ), writer.createText( ref ) );
+				writer.insert( writer.createPositionAt( container, 0 ), writer.createText( markerText ) );
 				return container;
 			},
 		} );
@@ -85,7 +131,9 @@ export default class OPMacroWpQuickinfoPlugin extends Plugin {
 		const mentionCommand = editor.commands.get( 'mention' );
 		if (!mentionCommand) return;
 
-		// Take over ##/### work_package mentions as a widget
+		// Take over ##/### work_package mentions as a widget; the data
+		// downcast chooses bare quickinfo or `<mention>` envelope at save
+		// time based on whether the id matches the displayed identifier.
 		mentionCommand.on( 'execute', ( evt, args ) => {
 			const opts = args && args[0];
 			if (!opts || !opts.mention) return;
@@ -97,14 +145,18 @@ export default class OPMacroWpQuickinfoPlugin extends Plugin {
 			evt.stop();
 
 			const detailed = marker === '###';
-			const wpId = String(opts.mention.idNumber);
+			const wpDisplayId = String(opts.mention.dataDisplayId);
+			const wpId = opts.mention.dataId != null ? String(opts.mention.dataId) : null;
+			const markerText = opts.mention.text || `${marker}${wpDisplayId}`;
 
 			editor.model.change( writer => {
 				const range = opts.range || editor.model.document.selection.getFirstRange();
 				if (range) {
 					writer.remove( range );
 				}
-				const el = writer.createElement( 'op-macro-wp-quickinfo', { wpId, detailed } );
+				const attrs = { wpDisplayId, detailed, markerText };
+				if (wpId) attrs.wpId = wpId;
+				const el = writer.createElement( 'op-macro-wp-quickinfo', attrs );
 				editor.model.insertContent( el, editor.model.document.selection );
 				writer.setSelection( writer.createPositionAfter( el ) );
 			} );

--- a/src/plugins/op-macro-wp-quickinfo/op-macro-wp-quickinfo-plugin.js
+++ b/src/plugins/op-macro-wp-quickinfo/op-macro-wp-quickinfo-plugin.js
@@ -3,6 +3,7 @@ import { Widget, toWidget } from '@ckeditor/ckeditor5-widget';
 
 import { isWorkPackageQuickinfoMention } from './predicate';
 
+const QUICKINFO_MODEL = 'op-macro-wp-quickinfo';
 const QUICKINFO_TAG = 'opce-macro-wp-quickinfo';
 
 // Renders OpenProject's ##/### work-package quickinfo references as inline
@@ -23,7 +24,7 @@ export default class OPMacroWpQuickinfoPlugin extends Plugin {
 		const model = editor.model;
 		const conversion = editor.conversion;
 
-		model.schema.register( 'op-macro-wp-quickinfo', {
+		model.schema.register( QUICKINFO_MODEL, {
 			allowWhere: '$text',
 			isInline: true,
 			isObject: true,
@@ -41,7 +42,7 @@ export default class OPMacroWpQuickinfoPlugin extends Plugin {
 				if (dataId && dataId !== wpDisplayId) {
 					attrs.wpId = dataId;
 				}
-				return writer.createElement( 'op-macro-wp-quickinfo', attrs );
+				return writer.createElement( QUICKINFO_MODEL, attrs );
 			},
 			converterPriority: 'high',
 		} );
@@ -60,13 +61,13 @@ export default class OPMacroWpQuickinfoPlugin extends Plugin {
 				const detailed = markerText.startsWith('###');
 				const wpId = viewElement.getAttribute( 'data-id' ) || '';
 				const wpDisplayId = viewElement.getAttribute( 'data-display-id' ) || wpId;
-				return writer.createElement( 'op-macro-wp-quickinfo', { wpId, wpDisplayId, detailed, markerText } );
+				return writer.createElement( QUICKINFO_MODEL, { wpId, wpDisplayId, detailed, markerText } );
 			},
 			converterPriority: 'highest',
 		} );
 
 		conversion.for( 'editingDowncast' ).elementToElement( {
-			model: 'op-macro-wp-quickinfo',
+			model: QUICKINFO_MODEL,
 			view: ( modelElement, { writer } ) => {
 				const wpDisplayId = modelElement.getAttribute( 'wpDisplayId' ) || '';
 				const detailed = !!modelElement.getAttribute( 'detailed' );
@@ -91,7 +92,7 @@ export default class OPMacroWpQuickinfoPlugin extends Plugin {
 		} );
 
 		conversion.for( 'dataDowncast' ).elementToElement( {
-			model: 'op-macro-wp-quickinfo',
+			model: QUICKINFO_MODEL,
 			view: ( modelElement, { writer } ) => {
 				const wpDisplayId = modelElement.getAttribute( 'wpDisplayId' ) || '';
 				const detailed = !!modelElement.getAttribute( 'detailed' );
@@ -156,7 +157,7 @@ export default class OPMacroWpQuickinfoPlugin extends Plugin {
 				}
 				const attrs = { wpDisplayId, detailed, markerText };
 				if (wpId) attrs.wpId = wpId;
-				const el = writer.createElement( 'op-macro-wp-quickinfo', attrs );
+				const el = writer.createElement( QUICKINFO_MODEL, attrs );
 				editor.model.insertContent( el, editor.model.document.selection );
 				writer.setSelection( writer.createPositionAfter( el ) );
 			} );

--- a/src/plugins/op-macro-wp-quickinfo/op-macro-wp-quickinfo-plugin.js
+++ b/src/plugins/op-macro-wp-quickinfo/op-macro-wp-quickinfo-plugin.js
@@ -133,9 +133,10 @@ export default class OPMacroWpQuickinfoPlugin extends Plugin {
 		const mentionCommand = editor.commands.get( 'mention' );
 		if (!mentionCommand) return;
 
-		// Take over ##/### work_package mentions as a widget; the data
-		// downcast chooses bare quickinfo or `<mention>` envelope at save
-		// time based on whether the id matches the displayed identifier.
+		// Take over ##/### work_package mentions as a widget; `wpId`
+		// presence on the model is the discriminator that keeps
+		// autocomplete picks as a `<mention>` envelope at save time so
+		// identity survives display-id renames.
 		mentionCommand.on( 'execute', ( evt, args ) => {
 			const opts = args && args[0];
 			if (!opts || !opts.mention) return;

--- a/src/plugins/op-macro-wp-quickinfo/predicate.js
+++ b/src/plugins/op-macro-wp-quickinfo/predicate.js
@@ -1,0 +1,10 @@
+// Used by the quickinfo widget upcast (to claim the element) and the
+// mention caster (to defer). One source of truth keeps the two in sync.
+
+const QUICKINFO_MARKER_RE = /^#{2,3}/;
+
+export function isWorkPackageQuickinfoMention(viewElement) {
+	if (viewElement.getAttribute('data-type') !== 'work_package') return false;
+	const text = viewElement.getAttribute('data-text');
+	return !!text && QUICKINFO_MARKER_RE.test(text);
+}

--- a/tests/commonmark/work-package-refs.test.js
+++ b/tests/commonmark/work-package-refs.test.js
@@ -22,14 +22,14 @@ describe('CommonMarkProcessor', () => {
 			it('upcasts ##6217 to <opce-macro-wp-quickinfo>', () => {
 				testDataProcessor(
 					'##6217',
-					'<p><opce-macro-wp-quickinfo data-detailed="false" data-id="6217">##6217</opce-macro-wp-quickinfo></p>'
+					'<p><opce-macro-wp-quickinfo data-detailed="false" data-display-id="6217" data-id="6217">##6217</opce-macro-wp-quickinfo></p>'
 				);
 			});
 
 			it('round-trips inside surrounding text', () => {
 				testDataProcessor(
 					'see ##6217 here',
-					'<p>see <opce-macro-wp-quickinfo data-detailed="false" data-id="6217">##6217</opce-macro-wp-quickinfo> here</p>'
+					'<p>see <opce-macro-wp-quickinfo data-detailed="false" data-display-id="6217" data-id="6217">##6217</opce-macro-wp-quickinfo> here</p>'
 				);
 			});
 		});
@@ -38,7 +38,7 @@ describe('CommonMarkProcessor', () => {
 			it('upcasts ###6217 to <opce-macro-wp-quickinfo data-detailed="true">', () => {
 				testDataProcessor(
 					'###6217',
-					'<p><opce-macro-wp-quickinfo data-detailed="true" data-id="6217">###6217</opce-macro-wp-quickinfo></p>'
+					'<p><opce-macro-wp-quickinfo data-detailed="true" data-display-id="6217" data-id="6217">###6217</opce-macro-wp-quickinfo></p>'
 				);
 			});
 		});
@@ -72,5 +72,116 @@ describe('CommonMarkProcessor', () => {
 				);
 			});
 		});
+
+		describe('semantic identifier shorthand', () => {
+			it('upcasts #PROJ-7 to a <mention>', () => {
+				testDataProcessor(
+					'#PROJ-7',
+					'<p><mention class="mention" data-id="PROJ-7" data-text="#PROJ-7" data-type="work_package">#PROJ-7</mention></p>'
+				);
+			});
+
+			it('upcasts ##PROJ-7 to <opce-macro-wp-quickinfo>', () => {
+				testDataProcessor(
+					'##PROJ-7',
+					'<p><opce-macro-wp-quickinfo data-detailed="false" data-display-id="PROJ-7" data-id="PROJ-7">##PROJ-7</opce-macro-wp-quickinfo></p>'
+				);
+			});
+
+			it('upcasts ###PROJ-7 to <opce-macro-wp-quickinfo data-detailed="true">', () => {
+				testDataProcessor(
+					'###PROJ-7',
+					'<p><opce-macro-wp-quickinfo data-detailed="true" data-display-id="PROJ-7" data-id="PROJ-7">###PROJ-7</opce-macro-wp-quickinfo></p>'
+				);
+			});
+
+			it('matches longer project identifiers like #MACROPROJ-42', () => {
+				testDataProcessor(
+					'#MACROPROJ-42',
+					'<p><mention class="mention" data-id="MACROPROJ-42" data-text="#MACROPROJ-42" data-type="work_package">#MACROPROJ-42</mention></p>'
+				);
+			});
+
+			it('matches identifiers with underscores (e.g. #MY_PROJ-1)', () => {
+				testDataProcessor(
+					'#MY_PROJ-1',
+					'<p><mention class="mention" data-id="MY_PROJ-1" data-text="#MY_PROJ-1" data-type="work_package">#MY_PROJ-1</mention></p>'
+				);
+			});
+
+			describe('boundary handling for semantic shape', () => {
+				it('does not match mid-word: foo#PROJ-1 stays as text', () => {
+					testDataProcessor(
+						'foo#PROJ-1',
+						'<p>foo#PROJ-1</p>'
+					);
+				});
+
+				it('does not match if followed by a word char: #PROJ-1abc stays as text', () => {
+					testDataProcessor(
+						'#PROJ-1abc',
+						'<p>#PROJ-1abc</p>'
+					);
+				});
+
+				it('does not match a trailing-dash-only shape: #PROJ- stays as text', () => {
+					testDataProcessor(
+						'#PROJ-',
+						'<p>#PROJ-</p>'
+					);
+				});
+
+				it('does not match lowercase project identifiers: #proj-1 stays as text', () => {
+					testDataProcessor(
+						'#proj-1',
+						'<p>#proj-1</p>'
+					);
+				});
+			});
+		});
+
+		describe('stored <mention> envelope round-trip', () => {
+			// The two fixtures differ only in attribute order — view
+			// stringify sorts alphabetically, DOM serialization preserves
+			// source order.
+			const inputFor = (text) =>
+				`<mention class="mention" data-id="42" data-text="${text}" data-type="work_package" data-display-id="KSTP-2">${text}</mention>`;
+			const viewFor = (text) =>
+				`<mention class="mention" data-display-id="KSTP-2" data-id="42" data-text="${text}" data-type="work_package">${text}</mention>`;
+
+			it('preserves single-hash <mention> envelope', () => {
+				testDataProcessor(
+					inputFor('#KSTP-2'),
+					`<p>${viewFor('#KSTP-2')}</p>`,
+					inputFor('#KSTP-2')
+				);
+			});
+
+			it('preserves double-hash <mention> envelope', () => {
+				testDataProcessor(
+					inputFor('##KSTP-2'),
+					`<p>${viewFor('##KSTP-2')}</p>`,
+					inputFor('##KSTP-2')
+				);
+			});
+
+			it('preserves triple-hash <mention> envelope', () => {
+				testDataProcessor(
+					inputFor('###KSTP-2'),
+					`<p>${viewFor('###KSTP-2')}</p>`,
+					inputFor('###KSTP-2')
+				);
+			});
+
+			it('collapses a legacy single-attribute envelope to bare data-text', () => {
+				const legacy = '<mention class="mention" data-id="6217" data-text="#6217" data-type="work_package">#6217</mention>';
+				testDataProcessor(
+					legacy,
+					`<p>${legacy}</p>`,
+					'#6217'
+				);
+			});
+		});
+
 	});
 });


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/74949

Paired with core PR https://github.com/opf/openproject/pull/23204 -- both ship together per the build repo's README.

# Contract

`data-id` = work-package id. `data-display-id` = user-facing identifier (`PROJ-7` in semantic mode, the numeric id in classic). Same convention on `<mention>` envelopes and `<opce-macro-wp-quickinfo>`. Matches `data-type="user"`/`"group"` mentions, which already used numeric `data-id`.

# Storage rule

One invariant across both modes:

- **Autocomplete pick → `<mention>` envelope.**
- **Source-typed shorthand → bare markdown.**

The presence of a record-id signal (`wpId` on the widget model, `data-display-id` on the wire) is the discriminator. Autocomplete picks set it; source-typed parses don't.

# Behaviour matrix

| Input | Editor view | Stored markdown |
|---|---|---|
| `#X` / `##X` / `###X` autocomplete (any mode) | mention link / quickinfo widget | `<mention data-id="<id>" data-display-id="<displayId>" data-text="…">…</mention>` |
| `#N` / `#PROJ-N` source-typed | plain text | bare `#N` / `#PROJ-N` |
| `##N` / `###N` source-typed | quickinfo widget | bare `##N` / `###N` |
| Reload of any stored envelope | corresponding link / widget | envelope preserved on save |
| Legacy `<mention data-id="42">` (no `data-display-id`) | mention link | collapses to `#42` |

# Notes

- The parser's reference regex matches `\d+|[A-Z][A-Z0-9_]*-\d+`. A token-walk guard skips promotion when the match sits inside an unclosed `<mention>` opening tag, so stored envelopes round-trip without losing their inner text.
- `data-display-id` is emitted only on work-package mentions — user/group mentions don't need a second slot.
- Source-typed semantic shorthand (no autocomplete pick) persists as bare markdown — the inline tokeniser can't resolve the record id synchronously. The backend renders both shapes identically; only the storage form differs.

# Merge checklist

- [x] Round-trip jest fixtures: `#PROJ-7`, `##PROJ-7`, `###PROJ-7`, `MACROPROJ-42`, `MY_PROJ-1`, boundary cases (`foo#PROJ-1`, `#PROJ-1abc`, trailing dash, lowercase), stored `<mention>` envelope round-trips for all three marker lengths, legacy single-attribute envelope.
- [x] Rebuild OpenProject vendor bundle before the paired core PR merges: `npm ci && OPENPROJECT_CORE=/path/to/openproject npm run build`. Commit the regenerated `ckeditor.js` and verify the diff mentions `data-display-id`.
- [x] Manual editor round-trip (semantic mode + semantic-converted project): type `#PROJ-1`, `##PROJ-1`, `###PROJ-1` → renders link / widget. Pick via autocomplete → markdown source contains the envelope. Reload, edit, save → round-trip clean.