### PR TITLE
[#72986] add plugin to insert wiki page links

### DIFF
--- a/src/op-plugins.js
+++ b/src/op-plugins.js
@@ -43,6 +43,7 @@ import { Autosave } from '@ckeditor/ckeditor5-autosave';
 import OpContentRevisions from "./plugins/op-content-revisions/op-content-revisions";
 import OPMacroWpQuickinfoPlugin from "./plugins/op-macro-wp-quickinfo/op-macro-wp-quickinfo-plugin";
 import OpMacroWikiPageLinkPlugin from "./plugins/op-macro-wiki-page-link/op-macro-wiki-page-link-plugin";
+import OpMacroWikiPageLinkAddExisting from "./plugins/op-macro-wiki-page-link/op-macro-wiki-page-link-add-existing";
 
 // We divide our plugins into separate concerns here
 // in order to enable / disable each group by configuration
@@ -51,6 +52,7 @@ export const opMacroPlugins = [
 	OPMacroEmbeddedTable,
 	OPMacroWpButtonPlugin,
 	OPChildPagesPlugin,
+	OpMacroWikiPageLinkAddExisting,
 ];
 
 export const opImageUploadPlugins = [

--- a/src/plugins/op-macro-wiki-page-link/macro-url.js
+++ b/src/plugins/op-macro-wiki-page-link/macro-url.js
@@ -1,0 +1,5 @@
+import { getOPPath } from "../op-context/op-context";
+
+export function macroUrl(editor, providerId, pageIdentifier, frameId) {
+	return getOPPath(editor).wikiPageLinkMacro(providerId, pageIdentifier, frameId)
+}

--- a/src/plugins/op-macro-wiki-page-link/op-macro-wiki-page-link-add-existing.js
+++ b/src/plugins/op-macro-wiki-page-link/op-macro-wiki-page-link-add-existing.js
@@ -51,12 +51,16 @@ export default class OpMacroWikiPageLinkAddExisting extends Plugin {
 	}
 
 	insertWikiPageLink(providerId, pageIdentifier) {
+		if (!providerId || !pageIdentifier) {
+			return;
+		}
+
 		const model = this.editor.model;
 
 		model.change(writer => {
 			const linkElement = writer.createElement(
 				OpMacroWikiPageLinkPlugin.modelElementName,
-				{ providerId, pageIdentifier, }
+				{ providerId, pageIdentifier }
 			);
 
 			model.insertContent(linkElement, model.document.selection);

--- a/src/plugins/op-macro-wiki-page-link/op-macro-wiki-page-link-add-existing.js
+++ b/src/plugins/op-macro-wiki-page-link/op-macro-wiki-page-link-add-existing.js
@@ -1,0 +1,65 @@
+import { Plugin } from "@ckeditor/ckeditor5-core";
+import { ButtonView } from "@ckeditor/ckeditor5-ui";
+
+import { getOPPath, getOPService } from "../op-context/op-context";
+import OpMacroWikiPageLinkPlugin from "./op-macro-wiki-page-link-plugin";
+
+export default class OpMacroWikiPageLinkAddExisting extends Plugin {
+	static get pluginName() {
+		return 'OpMacroWikiPageLinkAddExisting';
+	}
+
+	static get buttonName() {
+		return 'insertExistingWikiPageLink';
+	}
+
+	get label() {
+		return window.I18n.t('js.editor.macro.wikis.add_existing');
+	}
+
+	closeDialogHandler = this.handleCloseDialog.bind(this)
+
+	init() {
+		const editor = this.editor;
+
+		editor.ui.componentFactory.add(OpMacroWikiPageLinkAddExisting.buttonName, locale => {
+			const view = new ButtonView(locale);
+			view.set({ label: this.label, withText: true, });
+			view.on('execute', () => { this.runModalDialog(editor); });
+			return view;
+		})
+	}
+
+	runModalDialog(editor) {
+		document.addEventListener('dialog:close', this.closeDialogHandler);
+
+		const turboRequests = getOPService(editor, 'turboRequests');
+		const path = getOPPath(editor).inlineExistingWikiPageDialog();
+
+		void turboRequests.request(path, { method: 'GET' });
+	}
+
+	handleCloseDialog(event) {
+		if (event.detail.additional?.action !== 'close_dialog_and_inline') {
+			// A previous step was closed, not the final stage of the dialog we expect.
+			return;
+		}
+
+		document.removeEventListener('dialog:close', this.closeDialogHandler);
+		const { providerId, pageIdentifier } = event.detail.additional;
+		this.insertWikiPageLink(providerId, pageIdentifier);
+	}
+
+	insertWikiPageLink(providerId, pageIdentifier) {
+		const model = this.editor.model;
+
+		model.change(writer => {
+			const linkElement = writer.createElement(
+				OpMacroWikiPageLinkPlugin.modelElementName,
+				{ providerId, pageIdentifier, }
+			);
+
+			model.insertContent(linkElement, model.document.selection);
+		});
+	}
+}

--- a/src/plugins/op-macro-wiki-page-link/op-macro-wiki-page-link-plugin.js
+++ b/src/plugins/op-macro-wiki-page-link/op-macro-wiki-page-link-plugin.js
@@ -1,12 +1,17 @@
 import { Plugin } from "@ckeditor/ckeditor5-core";
 import { toWidget } from "@ckeditor/ckeditor5-widget";
-import { getOPPath } from "../op-context/op-context";
+
+import { macroUrl } from "./macro-url";
 
 const MODEL_ELEMENT_NAME = 'op-macro-wiki-page-link';
 
 export default class OpMacroWikiPageLinkPlugin extends Plugin {
 	static get pluginName() {
 		return 'OpMacroWikiPageLink';
+	}
+
+	static get modelElementName() {
+		return MODEL_ELEMENT_NAME;
 	}
 
 	init() {
@@ -40,7 +45,7 @@ export default class OpMacroWikiPageLinkPlugin extends Plugin {
 					'turbo-frame',
 					{
 						id: frameId,
-						src: this.macroUrl(providerId, pageIdentifier, frameId),
+						src: macroUrl(editor, providerId, pageIdentifier, frameId),
 						'data-provider-id': providerId,
 						'data-page-identifier': pageIdentifier,
 						'data-type': 'wiki-page-link',
@@ -67,7 +72,7 @@ export default class OpMacroWikiPageLinkPlugin extends Plugin {
 					'turbo-frame',
 					{
 						id: frameId,
-						src: this.macroUrl(providerId, pageIdentifier, frameId),
+						src: macroUrl(editor, providerId, pageIdentifier, frameId),
 						'data-provider-id': providerId,
 						'data-page-identifier': pageIdentifier,
 						'data-type': 'wiki-page-link',
@@ -79,9 +84,5 @@ export default class OpMacroWikiPageLinkPlugin extends Plugin {
 				return toWidget(wrapper, writer, { label: `[[[${providerId}:${pageIdentifier}]]]` });
 			}
 		});
-	}
-
-	macroUrl(providerId, pageIdentifier, frameId) {
-		return getOPPath(this.editor).wikiPageLinkMacro(providerId, pageIdentifier, frameId)
 	}
 }


### PR DESCRIPTION
# Ticket
[OP#XWI-35](https://community.openproject.org/wp/XWI-35)

# What are you trying to accomplish?
- enable toolbar button to insert a wiki page link

# What approach did you choose and why?
- register plugin in OP plugin list
- call modal dialogs and insert editor model after dialog closed

### Related core PR
https://github.com/opf/openproject/pull/23718
