### PR TITLE
[COMMS-645] Fix editor crash when an attachment upload is rejected

### DIFF
--- a/src/plugins/op-upload-resource-adapter.js
+++ b/src/plugins/op-upload-resource-adapter.js
@@ -27,6 +27,11 @@ export default class OpUploadResourceAdapter {
 					return this.buildResponse(result[0])
 				}).catch((error) => {
 					console.error("Failed upload %O", error);
+					// Re-throw so CKEditor's FileRepository marks the loader as failed
+					// and removes the placeholder. Previously the error was swallowed,
+					// leaving the upload to resolve with `undefined`; CKEditor then
+					// crashed reading the (missing) upload result ("unexpected-error").
+					throw OpUploadResourceAdapter.errorMessage(error);
 				});
 		})
 
@@ -34,6 +39,22 @@ export default class OpUploadResourceAdapter {
 
 	buildResponse(result) {
 		return { default: result._links.staticDownloadLocation.href };
+	}
+
+	// Extract the most readable message from whatever the attachments resource
+	// service rejected with (a HAL error response, a plain Error, or a string),
+	// so CKEditor can surface it instead of an opaque object.
+	static errorMessage(error) {
+		const halError = error && error.error;
+		if (halError && typeof halError.message === 'string') {
+			return halError.message;
+		}
+
+		if (error && typeof error.message === 'string') {
+			return error.message;
+		}
+
+		return String(error);
 	}
 
     abort() {


### PR DESCRIPTION
# Related PR(s)
https://github.com/opf/openproject/pull/23734

# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-645/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The upload adapter swallowed any rejection from attachFiles() with a bare console.error, so upload() resolved with `undefined`. CKEditor's FileRepository then treated the upload as successful and crashed reading the (missing) result ("unexpected-error: can't access property urls"), which the watchdog surfaced as a generic "An error occurred within CKEditor" message.

Re-throw a readable error message instead. The FileRepository loader now moves to the `error` state, removes the placeholder image cleanly, and exposes the backend message (e.g. "'image/webp' is not allowed for upload") so the host application can present it.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
