### PR TITLE
[OP-19548] Remove lodash/underscore global usage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -25,8 +25,6 @@ module.exports = {
 	},
 	// The test environment that will be used for testing
 	testEnvironment: "jsdom",
-	// The paths to modules that run some code to configure or set up the testing environment before each test
-	setupFiles: ['<rootDir>/jest.setup.js'],
 	// An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
 	transformIgnorePatterns: []
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,0 @@
-import { escape } from 'underscore'
-
-global._ = {
-	escape: escape
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,6 @@
         "terser-webpack-plugin": "^5.3.14",
         "turndown": "^7.2.0",
         "turndown-plugin-gfm": "^1.0.2",
-        "underscore": "^1.13.7",
         "webpack": "^5.98.0",
         "webpack-bundle-analyzer": "^4.10.2",
         "webpack-cli": "^6.0.1",
@@ -11413,12 +11412,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
-      "dev": true
-    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
@@ -19816,12 +19809,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true
-    },
-    "underscore": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "terser-webpack-plugin": "^5.3.14",
     "turndown": "^7.2.0",
     "turndown-plugin-gfm": "^1.0.2",
-    "underscore": "^1.13.7",
     "webpack": "^5.98.0",
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^6.0.1",

--- a/src/commonmark/utils/preprocessor.js
+++ b/src/commonmark/utils/preprocessor.js
@@ -1,3 +1,23 @@
+const HTML_ESCAPES = {
+	'&': '&amp;',
+	'<': '&lt;',
+	'>': '&gt;',
+	'"': '&quot;',
+	"'": '&#x27;',
+	'`': '&#x60;'
+};
+
+/**
+ * Escape the characters "&", "<", ">", '"', "'", and "`" in the given string.
+ * Mirrors the previous `_.escape` (underscore) behaviour so output is unchanged
+ * after dropping the global underscore/lodash dependency.
+ * @param {string} string
+ * @returns {string}
+ */
+function escapeHtml(string) {
+	return String(string).replace(/[&<>"'`]/g, char => HTML_ESCAPES[char]);
+}
+
 /**
  * Replace whitespace of text nodes within the given parents in the given root element.
  * @param {*} root An HTMLElement to look for text nodes within
@@ -26,7 +46,7 @@ export function textNodesPreprocessor(root, allowed_whitespace_nodes, allowed_ra
 		// Re-encode < and > that would otherwise be output as HTML by turndown
 		// https://github.com/domchristie/turndown/issues/106
 		if (!hasParentOfType(node, allowed_raw_nodes)) {
-			node.nodeValue = _.escape(node.nodeValue);
+			node.nodeValue = escapeHtml(node.nodeValue);
 		}
 	}
 }

--- a/src/mentions/user-mentions.js
+++ b/src/mentions/user-mentions.js
@@ -5,6 +5,18 @@ import {
 } from "../plugins/op-context/op-context";
 import { get } from '@rails/request.js';
 
+function uniqBy(items, keyFn) {
+	const seen = new Set();
+	return items.filter(item => {
+		const key = keyFn(item);
+		if (seen.has(key)) {
+			return false;
+		}
+		seen.add(key);
+		return true;
+	});
+}
+
 export function userMentions(queryText) {
 	const editor = this;
 	let resource = getOPResource(editor);
@@ -33,7 +45,7 @@ export function userMentions(queryText) {
 		get(url, { responseKind: 'json', query: { select: 'elements/_type,elements/id,elements/name' } })
 			.then(response => response.json)
 			.then(collection => {
-				resolve(_.uniqBy(collection._embedded.elements, (el) => el.id).map(mention => {
+				resolve(uniqBy(collection._embedded.elements, (el) => el.id).map(mention => {
 					const type = mention._type.toLowerCase();
 					const text = `@${mention.name}`;
 					const id = `@${mention.id}`;

--- a/src/plugins/op-context/op-context.js
+++ b/src/plugins/op-context/op-context.js
@@ -1,17 +1,17 @@
 export function getOP(editor) {
-	return _.get(editor.config, '_config.openProject');
+	return editor.config?._config?.openProject;
 }
 
 export function getOPResource(editor) {
-	return _.get(editor.config, '_config.openProject.context.resource');
+	return editor.config?._config?.openProject?.context?.resource;
 }
 
 export function getOPFieldName(editor) {
-	return _.get(editor.config, '_config.openProject.context.field');
+	return editor.config?._config?.openProject?.context?.field;
 }
 
 export function getPluginContext(editor) {
-	return _.get(editor.config, '_config.openProject.pluginContext');
+	return editor.config?._config?.openProject?.pluginContext;
 }
 
 export function getOPService(editor, name) {


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19548

# What are you trying to accomplish?

Core is dropping the global `_` (OP-17486). Replaces all `_.*` calls with native JS so this build no longer depends on it:

- op-context: `_.get` -> optional chaining
- user-mentions: `_.uniqBy` -> local Set-based helper
- preprocessor: `_.escape` -> local escapeHtml (underscore-exact map)
- drop jest.setup.js global `_` mock and the `underscore` devDependency


## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
