### PR TITLE
[COMMS-860] Add OpResizerGuard to handle inline image resizing

### DIFF
--- a/src/op-plugins.js
+++ b/src/op-plugins.js
@@ -45,6 +45,7 @@ import OPMacroWpQuickinfoPlugin from "./plugins/op-macro-wp-quickinfo/op-macro-w
 import OpMacroWikiPageLinkPlugin from "./plugins/op-macro-wiki-page-link/op-macro-wiki-page-link-plugin";
 import OpMacroWikiPageLinkAddExisting from "./plugins/op-macro-wiki-page-link/op-macro-wiki-page-link-add-existing";
 import OpMacroWikiPageLinkCreateNew from "./plugins/op-macro-wiki-page-link/op-macro-wiki-page-link-create-new";
+import OPResizerGuard from "./plugins/op-resizer-guard/op-resizer-guard-plugin";
 
 // We divide our plugins into separate concerns here
 // in order to enable / disable each group by configuration
@@ -80,6 +81,7 @@ export const builtinPlugins = [
 	ImageResize,
 	ImageToolbar,
 	OpImageAttachmentLookup,
+	OPResizerGuard,
 	Link,
 	List,
 	TodoList,

--- a/src/plugins/op-resizer-guard/op-resizer-guard-plugin.js
+++ b/src/plugins/op-resizer-guard/op-resizer-guard-plugin.js
@@ -1,0 +1,52 @@
+import { Plugin } from '@ckeditor/ckeditor5-core';
+import { WidgetResize } from '@ckeditor/ckeditor5-widget';
+
+// Guards the image resizer against the self-feeding redraw recursion that
+// crashes the editor when an inline image without a persisted width is selected.
+//
+// WidgetResize listens to EditorUI#update and (re)draws the selected resizer.
+// Resizer#redraw calls view.change() to write the measured size back to the
+// view, which re-emits EditorUI#update, which redraws again. For an inline image
+// with no stored width and resizeUnit:'px', the measured (sub-pixel, device-pixel
+// rounded) size never matches what was written, so the cycle never converges and
+// recurses until the call stack overflows — taking down the editor via the
+// watchdog and losing content (COMMS-861 / COMMS-860 / OP-19619).
+//
+// The redraw that view.change() triggers re-enters redrawSelectedResizer
+// synchronously (confirmed by the crash stack), so a simple in-progress flag is
+// enough to break the recursion: the legitimate first redraw still runs and the
+// resizer still renders; only the re-entrant redraw it would feed itself is
+// skipped.
+export default class OPResizerGuard extends Plugin {
+	static get requires() {
+		return [ WidgetResize ];
+	}
+
+	static get pluginName() {
+		return 'OPResizerGuard';
+	}
+
+	afterInit() {
+		const widgetResize = this.editor.plugins.get( 'WidgetResize' );
+
+		// The EditorUI#update listener (and the window-resize listener) call
+		// this.redrawSelectedResizer() through a throttled wrapper that looks the
+		// method up dynamically, so reassigning the instance method is enough to
+		// guard every entry point without touching the listener registration.
+		const original = widgetResize.redrawSelectedResizer.bind( widgetResize );
+		let inProgress = false;
+
+		widgetResize.redrawSelectedResizer = function () {
+			if ( inProgress ) {
+				return;
+			}
+
+			inProgress = true;
+			try {
+				return original();
+			} finally {
+				inProgress = false;
+			}
+		};
+	}
+}

--- a/tests/plugins/op-resizer-guard.test.js
+++ b/tests/plugins/op-resizer-guard.test.js
@@ -1,0 +1,84 @@
+import OPResizerGuard from '../../src/plugins/op-resizer-guard/op-resizer-guard-plugin.js';
+
+// Builds a minimal editor stub exposing only what the plugin touches:
+// editor.plugins.get('WidgetResize').
+const fakeEditorWith = widgetResize => ( {
+	plugins: {
+		get: name => ( name === 'WidgetResize' ? widgetResize : null )
+	}
+} );
+
+describe( 'OPResizerGuard', () => {
+	test( 'suppresses the synchronous re-entrant redraw', () => {
+		// Models WidgetResize#redrawSelectedResizer, whose view.change() write
+		// re-emits EditorUI#update and feeds itself another redraw synchronously.
+		// Without the guard this recurses until the call stack overflows.
+		let depth = 0;
+		let maxDepth = 0;
+
+		const widgetResize = {
+			redrawSelectedResizer() {
+				depth++;
+				maxDepth = Math.max( maxDepth, depth );
+				if ( depth < 5 ) {
+					this.redrawSelectedResizer();
+				}
+				depth--;
+			}
+		};
+
+		new OPResizerGuard( fakeEditorWith( widgetResize ) ).afterInit();
+
+		widgetResize.redrawSelectedResizer();
+
+		// The first (legitimate) redraw runs; the re-entrant one it feeds itself
+		// is skipped, so we never nest.
+		expect( maxDepth ).toBe( 1 );
+	} );
+
+	test( 'still runs the legitimate top-level redraw on every call', () => {
+		let calls = 0;
+		const widgetResize = {
+			redrawSelectedResizer() {
+				calls++;
+			}
+		};
+
+		new OPResizerGuard( fakeEditorWith( widgetResize ) ).afterInit();
+
+		widgetResize.redrawSelectedResizer();
+		widgetResize.redrawSelectedResizer();
+
+		expect( calls ).toBe( 2 );
+	} );
+
+	test( 'resets the in-progress flag and rethrows when the redraw fails', () => {
+		let calls = 0;
+		const widgetResize = {
+			redrawSelectedResizer() {
+				calls++;
+				throw new Error( 'boom' );
+			}
+		};
+
+		new OPResizerGuard( fakeEditorWith( widgetResize ) ).afterInit();
+
+		// The error must propagate, and the finally block must clear the flag so
+		// a later call is not permanently swallowed.
+		expect( () => widgetResize.redrawSelectedResizer() ).toThrow( 'boom' );
+		expect( () => widgetResize.redrawSelectedResizer() ).toThrow( 'boom' );
+		expect( calls ).toBe( 2 );
+	} );
+
+	test( 'returns the value produced by the original redraw', () => {
+		const widgetResize = {
+			redrawSelectedResizer() {
+				return 'redrawn';
+			}
+		};
+
+		new OPResizerGuard( fakeEditorWith( widgetResize ) ).afterInit();
+
+		expect( widgetResize.redrawSelectedResizer() ).toBe( 'redrawn' );
+	} );
+} );


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-860
https://community.openproject.org/projects/COMMS/work_packages/COMMS-861

# What are you trying to accomplish?
Prevents editor crash when resizing inline images without persisted width by adding a re-entrancy guard to WidgetResize.redrawSelectedResizer()

Root Cause Explained:
1. Inline images have no initial width (blocked by `op-image-attachment-lookup`)
2. resizeUnit: 'px' + device-pixel rounding causes measurements to diverge
3. CKEditor's `compareArrays()` guard fails → always calls `view.change()`
4. `view.change()` emits `EditorUI#update` → redraws again → loop


# What approach did you choose and why?
Guard `redrawSelectedResizer()` with a simple re-entrancy flag implemented via the new `OPResizerGuard` plugin. The first call runs normally, but on any synchronous re-entrant call from within the first call's `view.change()` is skipped. This breaks the loop while preserving the legitimate resize behavior.


# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
